### PR TITLE
PLF-7 Redesign log levels in log module

### DIFF
--- a/xylog/example_test.go
+++ b/xylog/example_test.go
@@ -34,8 +34,8 @@ func ExampleConfig() {
 	// You can customize configurations of a logger by xylog.Config.
 
 	// Allow is the configuration indicating which log level can be printed.
-	// Use "ALL" if you want to print all log levels.
-	xylog.Config(ExampleModule, xylog.Allow("INFO", "Error"))
+	// Use AllowAll for printing all logs and NoAllow for printing no log.
+	xylog.Config(ExampleModule, xylog.Allow(xylog.INFO))
 
 	// Format configures the log string format.
 	// Xylog provides some macros to format the log string:
@@ -52,6 +52,8 @@ func ExampleConfig() {
 	//     SFile  - similar to File, but it will write to another file if a
 	//              stop condition is reached. See ExampleSFile.
 	xylog.Config(ExampleModule, xylog.Writer(xylog.Stdout))
+	// or
+	// xylog.Config(ExampleModule, xylog.StdWriter())
 
 	// Note: Config() function allows you to pass a list of configurations
 	// instead of one by one.
@@ -66,18 +68,35 @@ func ExampleLog() {
 	// After you register a module (and configure if needed), you can begin
 	// to log anything you want.
 
-	// You can use any custom log level with xylog.Log.
-	xylog.Log(ExampleModule, "CUSTOM", "Any level can be logged")
+	// A log level contains two fields, the level number and level message.
+	// When you allow a level to be printed, all higher levels is allowed too.
+	// There are six built-in log levels in xylog.
+	// - 10 TRACE
+	// - 20 DEBUG
+	// - 50 INFO
+	// - 70 WARN
+	// - 80 ERROR
+	// - 90 CRITCAL
+
+	// If you want create your own log level, let you use RegisterLevel.
+	CUSTOM := xylog.RegisterLevel(33, "CUSTOM")
+
+	// Allow your log level and higher ones to be printed, including CUSTOM,
+	// INFO, WARN, ERROR, and CRITICAL.
+	xylog.Config(ExampleModule, xylog.Allow(CUSTOM))
+
+	// Using the generic Log to print your custom level.
+	xylog.Log(ExampleModule, CUSTOM, "Any level can be logged")
 
 	// Or use built-in log levels.
 	xylog.Info(ExampleModule, "Info")
 	xylog.Error(ExampleModule, "Something %s", "wrong")
 
-	// The below log level isn't printed because of Allow configuration in the
-	// ExampleConfig() function.
+	// DEBUG log level is not printed.
 	xylog.Debug(ExampleModule, "Debug something")
 
 	// Output:
+	// [CUSTOM][ExampleModule] - Any level can be logged
 	// [INFO][ExampleModule] - Info
 	// [ERROR][ExampleModule] - Something wrong
 }
@@ -87,10 +106,10 @@ func ExampleLogger() {
 	// the logger of that module by calling xylog.Logger.
 	ExampleLogger := xylog.Logger(ExampleModule)
 
-	// Functions of logger don't need module as a parameter to call.
+	// Functions of logger don't need the module as a parameter to call.
 	ExampleLogger.Config(
 		xylog.Format("$MESSAGE$ of ExampleLogger"),
-		xylog.Allow("Critical"),
+		xylog.Allow(xylog.CRITICAL),
 	)
 
 	ExampleLogger.Critical("Something is critical")
@@ -105,7 +124,7 @@ func ExampleFile() {
 
 	// Now, call log functions normally and all log messages will be put in
 	// file instead.
-	xylog.Config(ExampleModule, xylog.Allow("INFO"))
+	xylog.Config(ExampleModule, xylog.Allow(xylog.INFO))
 	xylog.Info(ExampleModule, "Info in file")
 
 	// This example doesn't print any output, see the log file for more details.
@@ -118,20 +137,17 @@ func ExampleSFile() {
 	// use SFile of Writer configuration to stop printing to a file when a
 	// condition is reached, the logger then creates another file to print.
 	fnFormat := "example_log_%s.log"
-	xylog.Config(ExampleModule, xylog.Writer(xylog.SFile(fnFormat, xylog.LimitSize(50*xylog.Byte))))
+	xylog.Config(ExampleModule, xylog.Writer(xylog.SFile(fnFormat, xylog.LimitSize(100*xylog.Byte))))
 	// Or you can split file by day
 	// xylog.Config(ExampleModule, xylog.Writer(xylog.SFile(fnFormat, xylog.TimePeriod(xylog.Day))))
 	// Or after one hour
 	// xylog.Config(ExampleModule, xylog.Writer(xylog.SFile(fnFormat, xylog.TimeAfter(time.Hour))))
 
 	// Now you can log normally and the log message will be printed to many files.
-	xylog.Config(ExampleModule, xylog.Allow("Info", "Error"))
+	xylog.Config(ExampleModule, xylog.Allow(xylog.INFO))
 	time.Sleep(time.Second)
 
 	xylog.Info(ExampleModule, "Something is logged but too long")
-	time.Sleep(time.Second)
-
-	xylog.Error(ExampleModule, "Something is wrong but too long")
 	time.Sleep(time.Second)
 
 	xylog.Error(ExampleModule, "Something is wrong but too long")

--- a/xylog/logger.go
+++ b/xylog/logger.go
@@ -1,30 +1,27 @@
 package xylog
 
 import (
-	"strings"
-
 	"github.com/xybor/xyplatform"
 )
 
 type logger struct {
 	module xyplatform.Module
 	format string
-	allow  map[string]bool
+	level  uint
 	output writer
 }
 
 // Log is a general log function allowing you to print a message with a custom
 // log level.
-func (lg logger) Log(level string, msg string, a ...interface{}) {
-	level = strings.ToUpper(level)
-
-	_, all := lg.allow["ALL"]
-	_, ok := lg.allow[level]
-	if !ok && !all {
+func (lg logger) Log(level uint, msg string, a ...interface{}) {
+	if level < lg.level {
 		return
 	}
 
-	log := replaceLog(lg.format, lg.module, level, msg, a...)
+	checkLevel(level)
+	levelName := levelManager[level]
+
+	log := replaceLog(lg.format, lg.module, levelName, msg, a...)
 
 	lg.output.write(log)
 }
@@ -40,34 +37,35 @@ func (lg *logger) Config(configurators ...configurator) bool {
 	return true
 }
 
-// Log normal actions, such as start or stop a process.
-func (lg logger) Info(msg string, a ...interface{}) {
-	lg.Log("INFO", msg, a...)
-}
-
-// Log errors but the program can recover, or something leads to unexpected
-// behaviors.
-func (lg logger) Warn(msg string, a ...interface{}) {
-	lg.Log("WARN", msg, a...)
-}
-
-// Log errors crashing the program, but errors come from external affects.
-// For example, FileNotFound or DatabaseError.
-func (lg logger) Error(msg string, a ...interface{}) {
-	lg.Log("ERROR", msg, a...)
-}
-
-// Log errors crashing the program, and errors is internal issues.
-func (lg logger) Critical(msg string, a ...interface{}) {
-	lg.Log("CRITICAL", msg, a...)
-}
-
-// Log helpful or diagnostic information for debugging.
-func (lg logger) Debug(msg string, a ...interface{}) {
-	lg.Log("DEBUG", msg, a...)
-}
-
-// Log information helps determine where the problem occurs.
+// Trace logs very detailed information for debugging.
 func (lg logger) Trace(msg string, a ...interface{}) {
-	lg.Log("TRACE", msg, a...)
+	lg.Log(TRACE, msg, a...)
+}
+
+// Debug logs helpful and diagnostic information for debugging.
+func (lg logger) Debug(msg string, a ...interface{}) {
+	lg.Log(DEBUG, msg, a...)
+}
+
+// Info logs normal actions, such as start and stop a process.
+func (lg logger) Info(msg string, a ...interface{}) {
+	lg.Log(INFO, msg, a...)
+}
+
+// Warn logs errors the program can recover and continue after that, or
+// something leads to unexpected behaviors.
+func (lg logger) Warn(msg string, a ...interface{}) {
+	lg.Log(WARN, msg, a...)
+}
+
+// Error logs errors causing the function or operation to be stopped, but it
+// could be fixed later.
+func (lg logger) Error(msg string, a ...interface{}) {
+	lg.Log(ERROR, msg, a...)
+}
+
+// Critical logs errors causing the application or program to be stopped, or
+// something needs to be fixed immediately.
+func (lg logger) Critical(msg string, a ...interface{}) {
+	lg.Log(CRITICAL, msg, a...)
 }

--- a/xylog/manage.go
+++ b/xylog/manage.go
@@ -2,11 +2,15 @@ package xylog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/xybor/xyplatform"
 )
 
 var manager = make(map[xyplatform.Module]*logger)
+
+var maxLevel = uint(100)
+var levelManager = make([]string, maxLevel)
 
 // Register adds a module to log manager and creates its logger. The returned
 // value of this function is meaningless, it only helps run the function in the
@@ -21,10 +25,30 @@ func Register(m xyplatform.Module) bool {
 		module: m,
 		output: Stdout,
 		format: "$TIME$ -- $MODULE$ [$LEVEL$] $MESSAGE$",
-		allow:  map[string]bool{"ALL": true},
+		level:  0,
 	}
 
 	return true
+}
+
+// RegisterLevel adds a log level to the manager. The returned value of this
+// function is equal to the value parameter, and it also helps run the function
+// in the global scope.
+func RegisterLevel(value uint, name string) uint {
+	if value >= maxLevel {
+		msg := fmt.Sprintf("The level value is expected less than %d, but "+
+			"got %d", maxLevel, value)
+		panic(msg)
+	}
+
+	if levelManager[value] != "" {
+		msg := fmt.Sprintf("Level value %d has already registered", value)
+		panic(msg)
+	}
+
+	levelManager[value] = strings.ToUpper(name)
+
+	return value
 }
 
 // Logger gets the logger of a registered module.
@@ -36,4 +60,11 @@ func Logger(m xyplatform.Module) *logger {
 	}
 
 	return lg
+}
+
+func checkLevel(level uint) {
+	if levelManager[level] == "" {
+		msg := fmt.Sprintf("Level %d has not registered yet", level)
+		panic(msg)
+	}
 }

--- a/xylog/writer.go
+++ b/xylog/writer.go
@@ -19,9 +19,9 @@ type stdout struct {
 // Stdout is a writer which prints log to standard output.
 var Stdout = &stdout{mutex: sync.Mutex{}}
 
-func (o *stdout) write(msg string, a ...interface{}) {
-	o.mutex.Lock()
-	defer o.mutex.Unlock()
+func (w *stdout) write(msg string, a ...interface{}) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
 
 	content := fmt.Sprintf(msg, a...)
 	fmt.Println(content)

--- a/xylog/xylog.go
+++ b/xylog/xylog.go
@@ -1,80 +1,78 @@
 package xylog
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/xybor/xyplatform"
 )
 
-var (
+const (
 	Byte  = int64(1)
 	KByte = 1024 * Byte
 	MByte = 1024 * KByte
 	GByte = 1024 * MByte
 )
 
-var (
+const (
 	Minute = time.Minute
 	Hour   = time.Hour
 	Day    = 24 * time.Hour
 	Week   = 7 * Day
 )
 
+var (
+	TRACE    = RegisterLevel(10, "TRACE")
+	DEBUG    = RegisterLevel(20, "DEBUG")
+	INFO     = RegisterLevel(50, "INFO")
+	WARN     = RegisterLevel(70, "WARN")
+	ERROR    = RegisterLevel(80, "ERROR")
+	CRITICAL = RegisterLevel(90, "CRITICAL")
+)
+
 var TimeFormat = "01-02-2006.15-04-05"
 
 // Log is a general log function allowing you to print a message with a custom
 // log level.
-func Log(m xyplatform.Module, level string, msg string, a ...interface{}) {
-	if _, ok := manager[m]; !ok {
-		msg := fmt.Sprintf("Module %s had not registered yet", m)
-		panic(msg)
-	}
-
-	manager[m].Log(level, msg, a...)
+func Log(m xyplatform.Module, level uint, msg string, a ...interface{}) {
+	Logger(m).Log(level, msg, a...)
 }
 
 // Config is a function allowing you to configure the logger. The returned
 // value of this function is meaningless, it only helps run it in the global
 // scope.
 func Config(m xyplatform.Module, configurators ...configurator) bool {
-	if _, ok := manager[m]; !ok {
-		msg := fmt.Sprintf("Module %s had not registered yet", m)
-		panic(msg)
-	}
-
-	return manager[m].Config(configurators...)
+	return Logger(m).Config(configurators...)
 }
 
-// Log errors but the program can recover, or something leads to unexpected
-// behaviors.
-func Info(m xyplatform.Module, msg string, a ...interface{}) {
-	Log(m, "INFO", msg, a...)
-}
-
-// Log errors crashing the program, but errors come from external affects.
-// For example, FileNotFound or DatabaseError.
-func Warn(m xyplatform.Module, msg string, a ...interface{}) {
-	Log(m, "WARN", msg, a...)
-}
-
-// Log errors crashing the program, but errors come from external affects.
-// For example, FileNotFound or DatabaseError.
-func Error(m xyplatform.Module, msg string, a ...interface{}) {
-	Log(m, "ERROR", msg, a...)
-}
-
-// Log errors crashing the program, and errors is internal issues.
-func Critical(m xyplatform.Module, msg string, a ...interface{}) {
-	Log(m, "CRITICAL", msg, a...)
-}
-
-// Log helpful or diagnostic information for debugging.
-func Debug(m xyplatform.Module, msg string, a ...interface{}) {
-	Log(m, "DEBUG", msg, a...)
-}
-
-// Log information helps determine where the problem occurs.
+// Trace logs very detailed information for debugging.
 func Trace(m xyplatform.Module, msg string, a ...interface{}) {
-	Log(m, "TRACE", msg, a...)
+	Logger(m).Trace(msg, a...)
+}
+
+// Debug logs helpful and diagnostic information for debugging.
+func Debug(m xyplatform.Module, msg string, a ...interface{}) {
+	Logger(m).Debug(msg, a...)
+}
+
+// Info logs normal actions, such as start and stop a process.
+func Info(m xyplatform.Module, msg string, a ...interface{}) {
+	Logger(m).Info(msg, a...)
+}
+
+// Warn logs errors the program can recover and continue after that, or
+// something leads to unexpected behaviors.
+func Warn(m xyplatform.Module, msg string, a ...interface{}) {
+	Logger(m).Warn(msg, a...)
+}
+
+// Error logs errors causing the function or operation to be stopped, but it
+// could be fixed later.
+func Error(m xyplatform.Module, msg string, a ...interface{}) {
+	Logger(m).Error(msg, a...)
+}
+
+// Critical logs errors causing the application or program to be stopped, or
+// something needs to be fixed immediately.
+func Critical(m xyplatform.Module, msg string, a ...interface{}) {
+	Logger(m).Critical(msg, a...)
 }


### PR DESCRIPTION
The current design of log levels is inconvenience. The new design should be:
- Each log level needs to map with a particular number to indicate the verbosity of that level.
- Register a new log level must use a function.
- It should be able display higher log levels if you allow a lower one.
- Change log level to uint instead of string.
- Add more documentations.

NOTE: the new design must not break the current api prototypes of this module.