### PR TITLE
PLF-15 Migrate to Go 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/xybor/xyplatform
 
-go 1.17
+go 1.18


### PR DESCRIPTION
Migrate to Go 1.18 to get the feature of type parameter (also called generic).