### PR TITLE
PLF-24 E-Selector returns an invalid index (larger than 1)

### DIFF
--- a/xyselect/eselector.go
+++ b/xyselect/eselector.go
@@ -52,7 +52,7 @@ func (es *eselector) recv(c <-chan any) int {
 			close(es.center)
 		}
 		es.mu.Unlock()
-	}(es.counter)
+	}(es.counter - 1)
 
 	return es.counter
 }


### PR DESCRIPTION
Problem: When use `xyselect.E()`, the index returned by Select() method, it is larger than the expected index by 1.

Root cause: The `counter` in `Recv()` method is increased before it is passed into the goroutine.

Solution: Pass `counter-1` into goroutine instead of `counter`.