### PR TITLE
PLF-25 XySelect Improvement: Implement mutex in its own selector, not safeSelector

### DIFF
--- a/xyselect/example_test.go
+++ b/xyselect/example_test.go
@@ -42,7 +42,7 @@ func ExampleR() {
 	var chans []chan int
 	for i := 0; i < 10; i++ {
 		chans = append(chans, make(chan int))
-		go func(c chan int, v int) {
+		go func(c chan<- int, v int) {
 			c <- v
 			close(c)
 		}(chans[i], i)
@@ -51,6 +51,7 @@ func ExampleR() {
 	rselector := xyselect.R()
 	for _, c := range chans {
 		rselector.Recv(xyselect.C(c))
+		rselector.Send(make(chan int, 1), 1)
 	}
 
 	okCounter := 0
@@ -61,7 +62,7 @@ func ExampleR() {
 			okCounter += 1
 		}
 
-		if okCounter == 10 {
+		if okCounter == 20 {
 			break
 		}
 	}

--- a/xyselect/rselector.go
+++ b/xyselect/rselector.go
@@ -1,13 +1,20 @@
 package xyselect
 
-import "reflect"
+import (
+	"reflect"
+	"sync"
+)
 
 // See documentation of R().
 type rselector struct {
 	cases []reflect.SelectCase
+	mu    sync.Mutex
 }
 
 func (rs *rselector) recv(c <-chan any) int {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
 	sc := reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(c)}
 	rs.cases = append(rs.cases, sc)
 
@@ -15,6 +22,9 @@ func (rs *rselector) recv(c <-chan any) int {
 }
 
 func (rs *rselector) send(c any, v any) int {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
 	sc := reflect.SelectCase{
 		Dir:  reflect.SelectSend,
 		Chan: reflect.ValueOf(c), Send: reflect.ValueOf(v),
@@ -26,17 +36,18 @@ func (rs *rselector) send(c any, v any) int {
 }
 
 func (rs *rselector) xselect(isDefault bool) (index int, value any, err error) {
+	rs.mu.Lock()
 	cases := rs.cases
-	n := len(cases)
+	rs.mu.Unlock()
+
 	if isDefault {
 		cases = append(cases, reflect.SelectCase{Dir: reflect.SelectDefault})
 	}
 
 	i, v, ok := reflect.Select(cases)
-	if i == n {
+	if i == len(cases)-1 && isDefault {
 		return 0, nil, DefaultCaseError.New("default case")
 	}
-
 	if !ok {
 		return i, nil, ClosedChannelError.New("channel is closed")
 	}


### PR DESCRIPTION
Problem: `xyselect` blocks unexpectedly when calling `Recv` (or `Send`) and `Select` simultaneously.

Root cause: mutex in `safeSelector`.

Solution: Move mutex to selectors.