### PR TITLE
PLF-26 Create a function Or() of error

### DIFF
--- a/xyerror/error.go
+++ b/xyerror/error.go
@@ -32,3 +32,14 @@ func (xerr xyerror) Is(target error) bool {
 
 	return xerr.c.belongsTo(tc)
 }
+
+// Or returns the first not-nil error. If all errors are nil, return nil.
+func Or(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Create a `Or` function to combine errors with the following example:

```
xyerror.Or(err1, nil) == err1
xyerror.Or(nil, err1) == err1
xyerror.Or(nil, nil) == nil
xyerror.Or(err1, err2) == err1
```