### PR TITLE
PLF-35 Allow use handlers throughout program based on their name

### DIFF
--- a/xylog/example_test.go
+++ b/xylog/example_test.go
@@ -1,6 +1,7 @@
 package xylog_test
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/xybor/xyplatform/xylog"
@@ -8,7 +9,7 @@ import (
 
 func Example() {
 	// You can directly use xylog functions to log with the root logger.
-	var handler = xylog.NewStreamHandler()
+	var handler = xylog.NewStreamHandler("")
 	handler.SetStream(os.Stdout)
 
 	xylog.SetLevel(xylog.DEBUG)
@@ -24,7 +25,7 @@ func Example() {
 }
 
 func ExampleGetLogger() {
-	var handler = xylog.NewStreamHandler()
+	var handler = xylog.NewStreamHandler("")
 	handler.SetStream(os.Stdout)
 	handler.SetFormatter(xylog.NewTextFormatter(
 		"module=%(name)s level=%(levelname)s %(message)s"))
@@ -36,4 +37,29 @@ func ExampleGetLogger() {
 
 	// Output:
 	// module=example level=DEBUG foo bar
+}
+
+func ExampleHandler() {
+	// You can use a handler throughout program without storing it in global
+	// scope. All handlers can be identified by their names.
+	var handlerA = xylog.NewStreamHandler("bar")
+	var handlerB = xylog.NewStreamHandler("bar")
+	if handlerA == handlerB {
+		fmt.Println("handlerA == handlerB")
+	} else {
+		fmt.Println("handlerA != handlerB")
+	}
+
+	// In case name is an empty string, it totally is a fresh handler.
+	var handlerC = xylog.NewStreamHandler("")
+	var handlerD = xylog.NewStreamHandler("")
+	if handlerC == handlerD {
+		fmt.Println("handlerC == handlerD")
+	} else {
+		fmt.Println("handlerC != handlerD")
+	}
+
+	// Output:
+	// handlerA == handlerB
+	// handlerC != handlerD
 }

--- a/xylog/logger.go
+++ b/xylog/logger.go
@@ -25,7 +25,7 @@ type Logger struct {
 	children map[string]*Logger
 	parent   *Logger
 	level    int
-	handlers []handler
+	handlers []Handler
 	lock     xylock.RWLock
 	cache    map[int]bool
 }
@@ -60,12 +60,12 @@ func (lg *Logger) SetLevel(level int) {
 }
 
 // AddHandler adds a new handler.
-func (lg *Logger) AddHandler(h handler) {
+func (lg *Logger) AddHandler(h Handler) {
 	lg.lock.WLockFunc(func() { lg.handlers = append(lg.handlers, h) })
 }
 
 // RemoveHandler removes an existed handler.
-func (lg *Logger) RemoveHandler(h handler) {
+func (lg *Logger) RemoveHandler(h Handler) {
 	lg.lock.WLockFunc(func() {
 		for i := range lg.handlers {
 			if lg.handlers[i] == h {

--- a/xylog/root.go
+++ b/xylog/root.go
@@ -1,12 +1,12 @@
 package xylog
 
 // AddHandler adds a new handler to root logger.
-func AddHandler(h handler) {
+func AddHandler(h Handler) {
 	rootLogger.AddHandler(h)
 }
 
 // RemoveHandler removes an existed handler from root logger.
-func RemoveHandler(h handler) {
+func RemoveHandler(h Handler) {
 	rootLogger.RemoveHandler(h)
 }
 

--- a/xyplatform.go
+++ b/xyplatform.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	var handler = xylog.NewStreamHandler()
+	var handler = xylog.NewStreamHandler("xyplatform")
 	handler.SetStream(os.Stdout)
 	handler.SetLevel(xylog.WARNING)
 	handler.SetFormatter(xylog.NewTextFormatter(


### PR DESCRIPTION
Handler may be reused throughout program or cross-modules. So we need a method to get a handler by its name.
Given one name, it should always return only exact one handler.