### PR TITLE
PLF-55 Xyselect returns an ClosedChannelError while select sending case

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![GitHub Repo stars](https://img.shields.io/github/stars/xybor/xyplatform?color=yellow)
 ![GitHub top language](https://img.shields.io/github/languages/top/xybor/xyplatform?color=lightblue)
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/xybor/xyplatform)
+![GitHub release (release name instead of tag name)](https://img.shields.io/github/v/release/xybor/xyplatform?include_prereleases)
 
 Xyplatform contains platform libraries developed by Xybor.
 
@@ -14,5 +15,7 @@ comparison and debugging.
 3. [xylock](./xylock) contains wrapper structs of built-in `sync` library, such
 as `sync.Mutex` or `semaphore.Weighted`.
 4. [xylog](./xylog) provides flexible logging methods to the program.
-5. [xyselect](./xyselect) is a library used to call `select` with an unknown
+5. [xysched](./xysched) provides a mechanism of job scheduling in future with a
+simple syntax.
+6. [xyselect](./xyselect) is a library used to call `select` with an unknown
 number of `case` statements.

--- a/xyselect/error.go
+++ b/xyselect/error.go
@@ -9,6 +9,5 @@ var egen = xyerror.Register("xyselect", 200000)
 var (
 	SelectorError      = egen.NewClass("SelectorError")
 	ClosedChannelError = SelectorError.NewClass("ClosedChannelError")
-	DefaultCaseError   = SelectorError.NewClass("DefaultCaseError")
 	ExhaustedError     = SelectorError.NewClass("ExhaustedError")
 )

--- a/xyselect/rselector.go
+++ b/xyselect/rselector.go
@@ -45,12 +45,16 @@ func (rs *rselector) xselect(isDefault bool) (index int, value any, err error) {
 	}
 
 	i, v, ok := reflect.Select(cases)
-	if i == len(cases)-1 && isDefault {
-		return 0, nil, DefaultCaseError.New("default case")
+	switch cases[i].Dir {
+	case reflect.SelectSend:
+		return i, nil, nil
+	case reflect.SelectRecv:
+		if ok {
+			return i, v.Interface(), nil
+		}
+		return i, nil, ClosedChannelError.New("channel closed")
+	default:
+		// reflect.SelectDefault
+		return -1, nil, nil
 	}
-	if !ok {
-		return i, nil, ClosedChannelError.New("channel is closed")
-	}
-
-	return i, v.Interface(), nil
 }

--- a/xyselect/selector.go
+++ b/xyselect/selector.go
@@ -115,10 +115,10 @@ func (s *Selector) Send(c any, v any) int {
 // can proceed and then executes that case. If isDefault is true, it will be
 // the non-blocking select.
 //
-// It returns the index of the chosen case, the value received, and a error of
-// selector. Nil for the case of receiving is not closed. DefaultCaseError for
-// the case of default. ExhaustedError if there is no more available channel in
-// exhausted-selector.
+// It returns the index of the chosen case (-1 if default case), the value
+// received, and a error of selector. Nil for the case of receiving is not
+// closed. ClosedChannelError if the channel is closed in receiving case,
+// ExhaustedError if there is no more available channel in exhausted-selector.
 func (s *Selector) Select(isDefault bool) (index int, v any, err error) {
 	return s.selector.xselect(isDefault)
 }


### PR DESCRIPTION
Problem: While testing with sending case, I receive a ClosedChannelError, which should be an error of receiving case.
Solution:
- Only return ClosedChannelError in case receiving channel.
- Modify `E` selector to return this error.