### PR TITLE
PLF-60 Refactor xycond functions to be easier to understand

### DIFF
--- a/xycond/example_test.go
+++ b/xycond/example_test.go
@@ -4,12 +4,12 @@ import "github.com/xybor/xyplatform/xycond"
 
 func ExampleCondition() {
 	// Assert 1 == 2
-	xycond.False(1 == 2).Assert("Weird")
+	xycond.MustFalse(1 == 2).Assert("weird")
 
 	// Assert x is 0
 	var x int
-	xycond.Zero(x).Assert("%d is not initialized with zero", x)
+	xycond.MustZero(x).Assert("%d is not initialized with zero", x)
 
 	// Assert string is empty, panic without any message if the condition fails.
-	xycond.Empty("").JustAssert()
+	xycond.MustEmpty("").JustAssert()
 }

--- a/xyerror/manage.go
+++ b/xyerror/manage.go
@@ -42,10 +42,11 @@ func getGenerator(errno int) Generator {
 // Register adds a Module with its identifier to managing pool for creating new
 // Classes.
 func Register(name string, id int) Generator {
-	xycond.Condition(id%minid == 0).
-		Assert("Cannot register: %d is not divisible by %d", id, minid)
+	xycond.MustTrue(id%minid == 0).
+		Assert("cannot register, %d is not divisible by %d", id, minid)
 	var gen = Generator{id}
-	xycond.NotContainM(manager, gen).Assert("Id %d had already registered", id)
+	xycond.MustNotContainM(manager, gen).
+		Assert("id %d had already registered", id)
 
 	manager[gen] = &errorinfo{name: name, count: 0}
 	return gen

--- a/xylog/config.go
+++ b/xylog/config.go
@@ -91,7 +91,7 @@ func GetLogger(name string) *Logger {
 	return lock.RWLockFunc(func() any {
 		var lg = rootLogger
 		for _, part := range strings.Split(name, ".") {
-			if xycond.NotContainM(lg.children, part) {
+			if xycond.MustNotContainM(lg.children, part) {
 				lg.children[part] = newlogger(part, lg)
 			}
 			lg = lg.children[part]
@@ -110,8 +110,8 @@ func getLevelName(level int) string {
 // checkLevel validates if the given level is registered or not.
 func checkLevel(level int) int {
 	return lock.RLockFunc(func() any {
-		xycond.ContainM(levelToName, level).
-			Assert("Level %d is not registered", level)
+		xycond.MustContainM(levelToName, level).
+			Assert("level %d is not registered", level)
 		return level
 	}).(int)
 }
@@ -128,7 +128,7 @@ func getHandler(name string) Handler {
 
 // mapHandler associates a name with a handler.
 func mapHandler(name string, h Handler) {
-	xycond.NotContainM(handlerManager, name).
-		Assert("Do not set handler with the same name: %s", name)
+	xycond.MustNotContainM(handlerManager, name).
+		Assert("do not set handler with the same name (%s)", name)
 	handlerManager[name] = h
 }

--- a/xylog/filter.go
+++ b/xylog/filter.go
@@ -26,7 +26,7 @@ func newfilterer() filterer {
 // AddFilter adds a specified filter.
 func (base *filterer) AddFilter(f Filter) {
 	base.lock.WLockFunc(func() {
-		if xycond.NotContainA(base.filters, f) {
+		if xycond.MustNotContainA(base.filters, f) {
 			base.filters = append(base.filters, f)
 		}
 	})

--- a/xylog/handler.go
+++ b/xylog/handler.go
@@ -97,8 +97,8 @@ func NewStreamHandler(name string) *StreamHandler {
 			mapHandler(name, handler)
 		}
 	} else {
-		xycond.SameType(handler, existedHandler).
-			Assert("Do use one name with two different handler types")
+		xycond.MustSameType(handler, existedHandler).
+			Assert("do use one name with two different handler types")
 		handler = existedHandler.(*StreamHandler)
 	}
 

--- a/xysched/cron.go
+++ b/xysched/cron.go
@@ -80,8 +80,8 @@ func (c *Cron) Twice() *Cron {
 func (c *Cron) Finish(f any, params ...any) *Task {
 	cb, ok := f.(future)
 	if ok {
-		xycond.Empty(params).
-			Assert("Do not pass params if f was already a tasker")
+		xycond.MustEmpty(params).
+			Assert("do not pass params if f was already a tasker")
 	} else {
 		cb = NewTask(f, params...)
 	}

--- a/xysched/task.go
+++ b/xysched/task.go
@@ -43,8 +43,8 @@ type Task struct {
 // future runs only one time.
 func NewTask(f any, params ...any) *Task {
 	var fv = reflect.ValueOf(f)
-	xycond.IsKind(f, reflect.Func).
-		Assert("Expected a function, but got %s", fv.Kind())
+	xycond.MustBe(f, reflect.Func).
+		Assert("expected a function, but got %s", fv.Kind())
 
 	return &Task{
 		fv: fv, params: params,
@@ -62,12 +62,12 @@ func NewTask(f any, params ...any) *Task {
 func (t *Task) Variadic(n int) *Task {
 	var ftype = t.fv.Type()
 	var nout = ftype.NumOut()
-	xycond.True(nout == 1).
-		Assert("Expected only one output, but %d found", nout)
+	xycond.MustTrue(nout == 1).
+		Assert("expected only one output, but %d found", nout)
 
 	var out = ftype.Out(0)
-	xycond.IsKind(out, reflect.Array, reflect.Slice).
-		Assert("Expected output as []any, but got %s", out.Kind())
+	xycond.MustBe(out, reflect.Array, reflect.Slice).
+		Assert("expected output as []any, but got %s", out.Kind())
 
 	t.variadic = true
 	t.ret = make([]any, n)
@@ -83,8 +83,8 @@ func (t *Task) Variadic(n int) *Task {
 func (t *Task) Callback(f any, params ...any) *Task {
 	cb, ok := f.(future)
 	if ok {
-		xycond.Empty(params).
-			Assert("Do not pass params if f was already a tasker")
+		xycond.MustEmpty(params).
+			Assert("do not pass params if f was already a future")
 	} else {
 		cb = NewTask(f, params...)
 	}

--- a/xysched/utils.go
+++ b/xysched/utils.go
@@ -15,10 +15,10 @@ func callFunc(fv reflect.Value, p []any, variadic bool) []any {
 	var ftype = fv.Type()
 	var ninput = ftype.NumIn()
 	if ftype.IsVariadic() {
-		xycond.Condition(len(p) >= ninput-1).Assert(
+		xycond.MustTrue(len(p) >= ninput-1).Assert(
 			"expected at least %d, but got %d parameters", ninput-1, len(p))
 	} else {
-		xycond.Condition(len(p) == ninput).
+		xycond.MustTrue(len(p) == ninput).
 			Assert("expected %d, but got %d parameters", ninput, len(p))
 	}
 

--- a/xyselect/selector.go
+++ b/xyselect/selector.go
@@ -92,13 +92,13 @@ func (s *Selector) Recv(c <-chan any) int {
 // Send adds a sending case to selector. The first parameter c must be a
 // writable channel. This method returns the index of the added case.
 func (s *Selector) Send(c any, v any) int {
-	xycond.IsWritableChan(c).
-		Assert("The first parameter of Send must be a writable channel.")
+	xycond.MustWritableChan(c).
+		Assert("the first parameter of Send must be a writable channel")
 
 	var cType = reflect.TypeOf(c)
 	var vType = reflect.TypeOf(v)
-	xycond.Condition(cType.Elem() == vType).Assert(
-		"channel and value must be the sametype, but got chan %s and %s.",
+	xycond.MustTrue(cType.Elem() == vType).Assert(
+		"channel and value must be the sametype, but got chan %s and %s",
 		cType.Elem(), vType)
 
 	return s.selector.send(c, v)


### PR DESCRIPTION
Problem: 
- Xycond functions don't make easy to read.
- Some causes unexpected panics when the input is not checked strictly.

Solution:
- Add Must word to every function’s names.
- Add more check in functions with type of any.