### PR TITLE
PLF-67 Refactor the design of Xylog Handler

### DIFF
--- a/xycond/condition.go
+++ b/xycond/condition.go
@@ -51,7 +51,13 @@ func MustNotZero[T number](a T) Condition {
 
 // MustNil returns true if a is nil.
 func MustNil(a any) Condition {
-	return Condition(a == nil)
+	if a == nil {
+		return true
+	}
+	if MustNotBe(a, reflect.Pointer) {
+		return false
+	}
+	return Condition(reflect.ValueOf(a).IsNil())
 }
 
 // MustNotNil returns true if a is not nil.
@@ -121,6 +127,11 @@ func MustBe(v any, kinds ...reflect.Kind) Condition {
 		}
 	}
 	return Condition(false)
+}
+
+// MustNotBe returns true if value doesn't belong to all of basic types.
+func MustNotBe(v any, kinds ...reflect.Kind) Condition {
+	return not(MustBe(v, kinds...))
 }
 
 // MustSameType returns true if values are the same type.

--- a/xylog/config.go
+++ b/xylog/config.go
@@ -13,7 +13,7 @@ import (
 func init() {
 	rootLogger = newlogger("", nil)
 	rootLogger.SetLevel(WARNING)
-	handlerManager = make(map[string]Handler)
+	handlerManager = make(map[string]*Handler)
 }
 
 var (
@@ -26,6 +26,12 @@ var (
 	DEBUG    = 10
 	NOTSET   = 0
 )
+
+// StdoutEmitter is a shortcut of NewStreamEmitter(os.Stdout)
+var StdoutEmitter = NewStreamEmitter(os.Stdout)
+
+// StderrEmitter is a shortcut of NewStreamEmitter(os.Stderr)
+var StderrEmitter = NewStreamEmitter(os.Stderr)
 
 // startTime is used as the base when calculating the relative time of events.
 var startTime = time.Now().UnixMilli()
@@ -47,10 +53,10 @@ var timeLayout = time.RFC3339Nano
 var defaultFormatter = NewTextFormatter("%(message)s")
 
 // lastHandler is used when no handler is configured to handle the log record.
-var lastHandler = NewStreamHandler("")
+var lastHandler = NewHandler("", StderrEmitter)
 
 // handlerManager is a map to search handler by name.
-var handlerManager map[string]Handler
+var handlerManager map[string]*Handler
 
 var levelToName = map[int]string{
 	CRITICAL: "CRITICAL",
@@ -116,9 +122,9 @@ func checkLevel(level int) int {
 	}).(int)
 }
 
-// getHandler returns the handler associated with the name. If no handler found,
+// GetHandler returns the handler associated with the name. If no handler found,
 // returns nil.
-func getHandler(name string) Handler {
+func GetHandler(name string) *Handler {
 	var h, ok = handlerManager[name]
 	if ok {
 		return h
@@ -127,7 +133,7 @@ func getHandler(name string) Handler {
 }
 
 // mapHandler associates a name with a handler.
-func mapHandler(name string, h Handler) {
+func mapHandler(name string, h *Handler) {
 	xycond.MustNotContainM(handlerManager, name).
 		Assert("do not set handler with the same name (%s)", name)
 	handlerManager[name] = h

--- a/xylog/example_test.go
+++ b/xylog/example_test.go
@@ -7,10 +7,14 @@ import (
 	"github.com/xybor/xyplatform/xylog"
 )
 
+// NOTE: In example_test.go, xylog.StdoutEmitter is not accepted as the compared
+// output. For this reason, in all examples, we must create a new one.
+// In reality, you should use xylog.StdoutEmitter or xylog.StderrEmitter
+// instead.
+
 func Example() {
 	// You can directly use xylog functions to log with the root logger.
-	var handler = xylog.NewStreamHandler("")
-	handler.SetStream(os.Stdout)
+	var handler = xylog.NewHandler("", xylog.NewStreamEmitter(os.Stdout))
 
 	xylog.SetLevel(xylog.DEBUG)
 	xylog.AddHandler(handler)
@@ -25,8 +29,7 @@ func Example() {
 }
 
 func ExampleGetLogger() {
-	var handler = xylog.NewStreamHandler("")
-	handler.SetStream(os.Stdout)
+	var handler = xylog.NewHandler("", xylog.NewStreamEmitter(os.Stdout))
 	handler.SetFormatter(xylog.NewTextFormatter(
 		"module=%(name)s level=%(levelname)s %(message)s"))
 
@@ -42,8 +45,8 @@ func ExampleGetLogger() {
 func ExampleHandler() {
 	// You can use a handler throughout program without storing it in global
 	// scope. All handlers can be identified by their names.
-	var handlerA = xylog.NewStreamHandler("bar")
-	var handlerB = xylog.NewStreamHandler("bar")
+	var handlerA = xylog.NewHandler("example", xylog.StdoutEmitter)
+	var handlerB = xylog.GetHandler("example")
 	if handlerA == handlerB {
 		fmt.Println("handlerA == handlerB")
 	} else {
@@ -51,8 +54,8 @@ func ExampleHandler() {
 	}
 
 	// In case name is an empty string, it totally is a fresh handler.
-	var handlerC = xylog.NewStreamHandler("")
-	var handlerD = xylog.NewStreamHandler("")
+	var handlerC = xylog.NewHandler("", xylog.StdoutEmitter)
+	var handlerD = xylog.NewHandler("", xylog.StdoutEmitter)
 	if handlerC == handlerD {
 		fmt.Println("handlerC == handlerD")
 	} else {

--- a/xylog/root.go
+++ b/xylog/root.go
@@ -1,12 +1,12 @@
 package xylog
 
 // AddHandler adds a new handler to root logger.
-func AddHandler(h Handler) {
+func AddHandler(h *Handler) {
 	rootLogger.AddHandler(h)
 }
 
 // RemoveHandler removes an existed handler from root logger.
-func RemoveHandler(h Handler) {
+func RemoveHandler(h *Handler) {
 	rootLogger.RemoveHandler(h)
 }
 

--- a/xyplatform.go
+++ b/xyplatform.go
@@ -1,17 +1,14 @@
 package xyplatform
 
 import (
-	"os"
-
 	"github.com/xybor/xyplatform/xylog"
 )
 
 func init() {
-	var handler = xylog.NewStreamHandler("xyplatform")
-	handler.SetStream(os.Stdout)
+	var handler = xylog.NewHandler("xybor.xyplatform", xylog.StderrEmitter)
 	handler.SetLevel(xylog.WARNING)
 	handler.SetFormatter(xylog.NewTextFormatter(
-		"time=%(asctime)s+%(msecs)d " +
+		"time=%(asctime)s " +
 			"source=%(filename)s.%(funcname)s:%(lineno)d " +
 			"level=%(levelname)s " +
 			"module=%(module)s " +


### PR DESCRIPTION
Problem:
- Currently, concrete `Handlers` and `BaseHandler` are interrelated. Such as, `StreamHandler` inherits from `BaseHandler` and `BaseHandler` contains the `StreamHandler` as an emitter.
- For this reason, designing new concrete `Handlers` in future will be too complex, especially in the `New__Handler` functions.
- We need to refactor the design of `Handler` to make it easy to develop.

Solution:
- Remove `Handler` interface.
- Change `BaseHandler` to `Handler`.
- Change `StreamHandler` to `StreamEmitter`. In the future, we will not create new `Handlers`. Instead, we create new `Emitters` and pass it to the `Handler`.