### PR TITLE
PLF-61 Index out of range when calling log methods with logger's name xybor.xyplatform.main

### DIFF
--- a/xylog/logger.go
+++ b/xylog/logger.go
@@ -192,7 +192,7 @@ func (lg *Logger) callHandlers(record LogRecord) {
 	var found = 0
 	for c != nil {
 		for i := range c.handlers {
-			lg.handlers[i].handle(record)
+			c.handlers[i].handle(record)
 			found += 1
 		}
 		c = c.parent

--- a/xylog/logger_test.go
+++ b/xylog/logger_test.go
@@ -116,6 +116,20 @@ func TestLoggerLogMethods(t *testing.T) {
 	}
 }
 
+func TestLoggerCallHandlerHierarchy(t *testing.T) {
+	var expectedMessage = "foo"
+	var handler = xylog.NewHandler("", &CapturedEmitter{})
+	var logger = xylog.GetLogger(t.Name())
+	logger.SetLevel(xylog.DEBUG)
+	logger.AddHandler(handler)
+
+	logger = xylog.GetLogger(t.Name() + ".main")
+	capturedOutput = ""
+	logger.Info(expectedMessage)
+	xycond.MustEqual(capturedOutput, expectedMessage).
+		Testf(t, "%s != %s", capturedOutput, expectedMessage)
+}
+
 func TestLoggerLogNoHandler(t *testing.T) {
 	var logger = xylog.GetLogger(t.Name())
 	logger.SetLevel(xylog.DEBUG)


### PR DESCRIPTION
Problem:
An error "index of out range" occured when calling log methods with a hierarchy logger `"xybor.xyplatform.main"`. The handler is only added to the parent `"xybor.xyplatform"`.
    
Solution:
A typo appears in Logger.callHandlers method. Change `lg` to `c` in that method.