### PR TITLE
PLF-51 Xycond should panic a Xyerror instead of string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
-# Developmet
-1. Fix ClosedChannelError in xyselect.
+# Developing
+1. Fix bugs.
+2. Refactor the design of xylog Handler.
+3. Add github workflow to test.
+4. Write unittest for all modules.
+5. Xycond asserts a Error instead of string.
+
 
 # V1.0.0
 This release completed the following libraries:

--- a/xycond/condition.go
+++ b/xycond/condition.go
@@ -2,9 +2,10 @@ package xycond
 
 import (
 	"fmt"
-	"log"
 	"reflect"
 	"runtime"
+
+	"github.com/xybor/xyplatform/xyerror"
 )
 
 // tester instances represent testing.T or testing.B.
@@ -24,7 +25,7 @@ func not(c Condition) Condition {
 // JustAssert panics the program without a message if condition fails.
 func (c Condition) JustAssert() {
 	if !c {
-		panic("Something was wrong")
+		panic(xyerror.AssertionError.New(""))
 	}
 }
 
@@ -32,7 +33,7 @@ func (c Condition) JustAssert() {
 // fails.
 func (c Condition) Assert(format string, args ...any) {
 	if !c {
-		panic(fmt.Sprintf(format, args...))
+		panic(xyerror.AssertionError.New(format, args...))
 	}
 }
 
@@ -53,9 +54,9 @@ func (c Condition) Testf(t tester, format string, args ...any) {
 	if !c {
 		var _, fn, ln, ok = runtime.Caller(1)
 		if ok {
-			log.Printf("%s:%d\n", fn, ln)
+			fmt.Printf("%s:%d\n", fn, ln)
 		}
-		log.Printf(format, args...)
+		fmt.Printf(format, args...)
 		t.Fail()
 	}
 }
@@ -87,7 +88,7 @@ func MustPanic(f func()) (c Condition) {
 			c = false
 		} else {
 			c = true
-			log.Println(r)
+			fmt.Println(r)
 		}
 	}()
 

--- a/xyerror/default.go
+++ b/xyerror/default.go
@@ -12,4 +12,5 @@ var (
 	ValueError          = defaultGen.NewClass("ValueError")
 	ParameterError      = defaultGen.NewClass("ParameterError")
 	TypeError           = defaultGen.NewClass("TypeError")
+	AssertionError      = defaultGen.NewClass("AssertionError")
 )

--- a/xyerror/manage.go
+++ b/xyerror/manage.go
@@ -1,7 +1,7 @@
 package xyerror
 
 import (
-	"github.com/xybor/xyplatform/xycond"
+	"log"
 )
 
 // Generator is used to generate root Class for every module. It is determined
@@ -42,11 +42,13 @@ func getGenerator(errno int) Generator {
 // Register adds a Module with its identifier to managing pool for creating new
 // Classes.
 func Register(name string, id int) Generator {
-	xycond.MustTrue(id%minid == 0).
-		Assert("cannot register, %d is not divisible by %d", id, minid)
+	if id%minid != 0 {
+		log.Panicf("cannot register, %d is not divisible by %d", id, minid)
+	}
 	var gen = Generator{id}
-	xycond.MustNotContainM(manager, gen).
-		Assert("id %d had already registered", id)
+	if _, ok := manager[gen]; ok {
+		log.Panicf("id %d had already registered", id)
+	}
 
 	manager[gen] = &errorinfo{name: name, count: 0}
 	return gen


### PR DESCRIPTION
`xycond` currently panics a string. This type is not easy to debug and recover.

It should panics a `XyError` instead of string.