### PR TITLE
PLF-58 Improve style in format log message

### DIFF
--- a/xylog/README.md
+++ b/xylog/README.md
@@ -120,13 +120,13 @@ if it allows to log the `LogRecord`, and vice versa.
 | GetRandomLogger    |        315ns|
 | GetSameHandler     |          5ns|
 | GetRandomHandler   |         17ns|
-| TextFormatter      |       9352ns|
+| TextFormatter      |        734ns|
 | LogWithoutHandler  |         31ns|
-| LogWithOneHandler  |       2517ns|
-| LogWith100Handler  |      19451ns|
-| LogWithStream      |      30703ns|
-| LogWithFile        |      36048ns|
-| LogWithRotateFile  |      40755ns|
+| LogWithOneHandler  |       2970ns|
+| LogWith100Handler  |      24912ns|
+| LogWithStream      |       8608ns|
+| LogWithFile        |      13509ns|
+| LogWithRotateFile  |      20082ns|
 
 # Example
 ## Simple usage

--- a/xylog/formatter.go
+++ b/xylog/formatter.go
@@ -2,8 +2,8 @@ package xylog
 
 import (
 	"fmt"
-	"reflect"
-	"strings"
+
+	"github.com/xybor/xyplatform/xycond"
 )
 
 // Formatter instances are used to convert a LogRecord to text.
@@ -18,46 +18,56 @@ type Formatter interface {
 // The TextFormatter can be initialized with a format string which makes use of
 // knowledge of the LogRecord attributes - e.g. %(message)s or %(levelno)d. See
 // LogRecord for more details.
-type textFormatter string
+type textFormatter struct {
+	formatstring  string
+	attrbuteIndex []int
+}
 
 // NewTextFormatter creates a textFormatter which uses LogRecord attributes to
 // contribute logging string, e.g. %(message)s or %(levelno)d. See LogRecord for
 // more details.
-func NewTextFormatter(f string) textFormatter {
-	return textFormatter(f)
+func NewTextFormatter(s string) textFormatter {
+	var record = LogRecord{}
+	var attributeIndex []int
+	var fmtstr = ""
+	var i, n = 0, len(s)
+	for i < n {
+		fmtstr += string(s[i])
+		if s[i] == '%' {
+			xycond.MustTrue(i+1 < n).Assert("unexpectedly end with %%")
+			i++
+			switch s[i] {
+			case '%':
+			case '(':
+				i++
+				var token = ""
+				for {
+					xycond.MustTrue(i < n).Assert("uncompleted token %s", token)
+					if s[i] == ')' {
+						break
+					}
+					token += string(s[i])
+					i++
+				}
+				attributeIndex = append(attributeIndex, record.mapName(token))
+			default:
+				xycond.Panic("unexpected token: %s", s[i-2:i])
+			}
+		}
+		i++
+	}
+
+	return textFormatter{
+		formatstring:  fmtstr,
+		attrbuteIndex: attributeIndex,
+	}
 }
 
 // Format creates a logging string by combine format string and logging record.
 func (f textFormatter) Format(record LogRecord) string {
-	var m = tomap(record)
-	var s = string(f)
-	for k, v := range m {
-		var token = "%(" + k + ")" // %(foo)
-		for {
-			var index = strings.Index(s, token)
-			if index == -1 {
-				break
-			}
-			token = s[index : index+len(token)+1]    // %(foo)s
-			var verb = "%" + token[len(token)-1:]    // %s
-			var value = fmt.Sprintf(verb, v)         // bar
-			s = strings.Replace(s, token, value, -1) // %(foo)s -> bar
-		}
+	var attrs = make([]any, len(f.attrbuteIndex))
+	for i := range f.attrbuteIndex {
+		attrs[i] = record.mapIndex(f.attrbuteIndex[i])
 	}
-
-	return s
-}
-
-// tomap converts a struct to map[string]any.
-func tomap(a any) map[string]any {
-	var result = make(map[string]any)
-	var v = reflect.ValueOf(a)
-	for i := 0; i < v.NumField(); i++ {
-		var f = v.Type().Field(i)
-		var tag = f.Tag.Get("map")
-		if tag != "" {
-			result[tag] = v.Field(i).Interface()
-		}
-	}
-	return result
+	return fmt.Sprintf(f.formatstring, attrs...)
 }

--- a/xylog/formatter_test.go
+++ b/xylog/formatter_test.go
@@ -1,0 +1,54 @@
+package xylog_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/xybor/xyplatform/xycond"
+	"github.com/xybor/xyplatform/xylog"
+)
+
+func TestNewTextFormatter(t *testing.T) {
+	var f = xylog.NewTextFormatter(
+		"time=%(asctime)s %(levelno).3d %(module)s something")
+	xycond.MustTrue(strings.Contains(
+		fmt.Sprint(f),
+		"time=%s %.3d %s something",
+	)).Testf(t, "Got unepected formatter %v", f)
+}
+
+func TestNewTextFormatterWithPercentageSign(t *testing.T) {
+	var f = xylog.NewTextFormatter(
+		"%%abc)s")
+	xycond.MustTrue(strings.Contains(fmt.Sprint(f), "%abc)s")).
+		Testf(t, "Got unepected formatter %v", f)
+}
+
+func TestTextFormatter(t *testing.T) {
+	var formatter = xylog.NewTextFormatter(
+		"%(asctime)s %(created)d %(filename)s %(funcname)s %(levelname)s " +
+			"%(levelno)d %(lineno)d %(message)s %(module)s %(msecs)d " +
+			"%(name)s %(pathname)s %(process)d %(relativeCreated)d")
+
+	var s = formatter.Format(xylog.LogRecord{
+		Asctime:         "ASCTIME",
+		Created:         1,
+		FileName:        "FILENAME",
+		FuncName:        "FUNCNAME",
+		LevelName:       "LEVELNAME",
+		LevelNo:         2,
+		LineNo:          3,
+		Message:         "MESSAGE",
+		Module:          "MODULE",
+		Msecs:           4,
+		Name:            "NAME",
+		PathName:        "PATHNAME",
+		Process:         5,
+		RelativeCreated: 6,
+	})
+
+	xycond.MustEqual(s, "ASCTIME 1 FILENAME FUNCNAME LEVELNAME 2 3 MESSAGE "+
+		"MODULE 4 NAME PATHNAME 5 6",
+	).Testf(t, "Got unexpected formatted string: %s", s)
+}

--- a/xylog/record.go
+++ b/xylog/record.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/xybor/xyplatform/xycond"
 )
 
 // A LogRecord instance represents an event being logged.
@@ -15,49 +17,121 @@ import (
 // was created or the source line where the logging call was made.
 type LogRecord struct {
 	// Textual time when the LogRecord was created.
-	Asctime string `map:"asctime"`
+	Asctime string
 
 	// Time when the LogRecord was created (time.Now().Unix() return value).
-	Created int64 `map:"created"`
+	Created int64
 
 	// Filename portion of pathname.
-	FileName string `map:"filename"`
+	FileName string
 
 	// Function name logged the record.
-	FuncName string `map:"funcname"`
+	FuncName string
 
 	// Text logging level for the message ("DEBUG", "INFO", "WARNING", "ERROR",
 	// "CRITICAL").
-	LevelName string `map:"levelname"`
+	LevelName string
 
 	// Numeric logging level for the message (DEBUG, INFO, WARNING, ERROR,
 	// CRITICAL).
-	LevelNo int `map:"levelno"`
+	LevelNo int
 
 	// Source line number where the logging call was issued.
-	LineNo int `map:"lineno"`
+	LineNo int
 
 	// The logging message.
-	Message string `map:"message"`
+	Message string
 
 	// The module called log method.
-	Module string `map:"module"`
+	Module string
 
 	// Millisecond portion of the creation time.
-	Msecs int `map:"msecs"`
+	Msecs int
 
 	// Name of the logger.
-	Name string `map:"name"`
+	Name string
 
 	// Full pathname of the source file where the logging call was issued.
-	PathName string `map:"pathname"`
+	PathName string
 
 	// Process ID.
-	Process int `map:"process"`
+	Process int
 
 	// Time in milliseconds when the LogRecord was created, relative to the time
 	// the logging module was loaded (typically at application startup time).
-	RelativeCreated int64 `map:"relativeCreated"`
+	RelativeCreated int64
+}
+
+func (r LogRecord) mapIndex(i int) any {
+	switch i {
+	case 0:
+		return r.Asctime
+	case 1:
+		return r.Created
+	case 2:
+		return r.FileName
+	case 3:
+		return r.FuncName
+	case 4:
+		return r.LevelName
+	case 5:
+		return r.LevelNo
+	case 6:
+		return r.LineNo
+	case 7:
+		return r.Message
+	case 8:
+		return r.Module
+	case 9:
+		return r.Msecs
+	case 10:
+		return r.Name
+	case 11:
+		return r.PathName
+	case 12:
+		return r.Process
+	case 13:
+		return r.RelativeCreated
+	default:
+		xycond.Panic("unknown index %d", i)
+		return nil
+	}
+}
+
+func (r LogRecord) mapName(name string) int {
+	switch name {
+	case "asctime":
+		return 0
+	case "created":
+		return 1
+	case "filename":
+		return 2
+	case "funcname":
+		return 3
+	case "levelname":
+		return 4
+	case "levelno":
+		return 5
+	case "lineno":
+		return 6
+	case "message":
+		return 7
+	case "module":
+		return 8
+	case "msecs":
+		return 9
+	case "name":
+		return 10
+	case "pathname":
+		return 11
+	case "process":
+		return 12
+	case "relativeCreated":
+		return 13
+	default:
+		xycond.Panic("unknown name %s", name)
+		return -1
+	}
 }
 
 // makeRecord creates specialized LogRecords.


### PR DESCRIPTION
The style `%` need to comply with format verb of golang, `%[flag][width][.precision]verb`.