### PR TITLE
PLF-75 Allow to use the new log format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Developing
-1. Add FileEmitter and RotatingFileEmitter to xylog.
+1.  Add FileEmitter and RotatingFileEmitter to xylog.
+2.  Xylog now can be easy to use key-value fields and extra values.
 
 # V1.0.1
 1. Fix bugs.

--- a/xylog/README.md
+++ b/xylog/README.md
@@ -1,23 +1,26 @@
 # Introduction
+
 Xylog provides flexible logging methods to the program.
 
 This package is inspired by idea of Python `logging`.
 
 # Feature
+
 The basic structs defined by the module, together with their functions, are
 listed below.
-1. Loggers expose the interface that application code directly uses.
-2. Handlers convert log records (created by loggers) to log messages, then send
-them to the Emitter.
-3. Emitters write log messages to appropriate destination.
-4. Filters provide a finer grained facility for determining which log records to
-output.
-5. Formatters specify the layout of log records in the final output.
+1.  Loggers expose the interface that application code directly uses.
+2.  Handlers convert log records (created by loggers) to log messages, then send
+    them to the Emitter.
+3.  Emitters write log messages to appropriate destination.
+4.  Filters provide a finer grained facility for determining which log
+    records to output.
+5.  Formatters specify the layout of log records in the final output.
 
 Visit [pkg.go.dev](https://pkg.go.dev/github.com/xybor/xyplatform/xylog) for
 more details.
 
 ## Logger
+
 Loggers should NEVER be instantiated directly, but always through the
 module-level function `xylog.GetLogger(name)`. Multiple calls to `GetLogger()`
 with the same name will always return a reference to the same Logger object.
@@ -39,7 +42,13 @@ To add `Handler` or `Filter` instances to the `logger`, call `AddHandler` or
 
 To adjust the level, using `SetLevel` method.
 
+### EventLogger
+
+`EventLogger` is a logger wrapper supporting to compose logging message by
+key-value fields.
+
 ## Logging level
+
 The numeric values of logging levels are given in the following table. These are
 primarily of interest if you want to define your own levels, and need them to
 have specific values relative to the predefined levels. If you define a level
@@ -55,6 +64,7 @@ name is lost.
 | NOTSET         |               0|
 
 ## Handler
+
 `Handler` handles logging events. A `Handler` need to be instantiated with an `Emitter` instance rather than creating directly.
 
 Any `Handler` with a not-empty name will be associated with its name. Calling
@@ -68,6 +78,7 @@ To get an existed `Handler`, call `GetHandler` with its name.
 Like `Logger`, `Handler` is also able to call `AddFilter`.
 
 ## Emitter
+
 `Emitter` instances write log messages to specified destination.
 
 `StreamEmitter` can be used to print logging message into stdout or stderr.
@@ -77,6 +88,7 @@ log into another file if the file exceed the limit size or time.
 
 
 ## Formatter
+
 `Formatter` instances are used to convert a `LogRecord` to text.
 
 `Formatter` need to know how a `LogRecord` is constructed. They are responsible
@@ -104,6 +116,7 @@ the message.
 |`relativeCreated`  |Time in milliseconds when the LogRecord was created, relative to the time the logging module was loaded (typically at application startup time).|
 
 ## Filter
+
 `Filter` instances are used to perform arbitrary filtering of `LogRecord`.
 
 A `Filter` struct needs to define `Format(LogRecord)` method, which return true
@@ -129,7 +142,9 @@ if it allows to log the `LogRecord`, and vice versa.
 | LogWithRotateFile  |      20082ns|
 
 # Example
+
 ## Simple usage
+
 ```golang
 var handler = xylog.NewHandler("xybor", xylog.StdoutEmitter)
 handler.SetFormatter(xylog.NewTextFormmater("%(level)s %(message)s"))
@@ -145,6 +160,7 @@ logger.Debug("foo")
 ```
 
 ## Rotating File Emitter
+
 ```golang
 // Create a rotating emitter which rotates to another files if current file
 // size is over than 30 bytes. Backup maximum of two log files.
@@ -179,6 +195,7 @@ if _, err := os.Stat("example.log.2"); err == nil {
 ```
 
 ## Get the existed Handler
+
 ```golang
 // Get the handler of the first example.
 var handler = xylog.GetHandler("xybor")
@@ -190,7 +207,24 @@ logger.Critical("foo foo")
 // CRITICAL foo foo
 ```
 
+## Event Logger
+
+```golang
+var handler = xylog.NewHandler("", xylog.NewStreamEmitter(os.Stdout))
+handler.SetFormatter(xylog.NewTextFormatter(
+    "module=%(name)s level=%(levelname)s %(message)s"))
+
+var logger = xylog.GetLogger("example")
+logger.AddHandler(handler)
+logger.SetLevel(xylog.DEBUG)
+logger.Event("create").Field("product", 1235).Debug()
+
+// Output:
+// module=example level=DEBUG event=create product=1235
+```
+
 ## Filter definition
+
 ```golang
 // LoggerNameFilter only logs out records belongs to a specified logger.
 type LoggerNameFilter struct {
@@ -214,6 +248,7 @@ xylog.GetLogger("xybor.service.chat").Debug("chat foo")
 ```
 
 ## Root logger
+
 ```golang
 // A simple program with only one application area could use directly the root
 // logger.
@@ -228,6 +263,7 @@ xylog.Debug("bar")
 ```
 
 ## Xyplatform log
+
 ```golang
 // example.go
 package foo

--- a/xylog/config.go
+++ b/xylog/config.go
@@ -65,6 +65,10 @@ var fileflag = os.O_WRONLY | os.O_APPEND | os.O_CREATE
 // fileperm is the file permission when creating a logging file.
 var fileperm fs.FileMode = 0666
 
+// skipCall is the depth of Logger.log call in program, 2 by default. Increase
+// this value if you want to wrap log methods of logger.
+var skipCall = 2
+
 var levelToName = map[int]string{
 	CRITICAL: "CRITICAL",
 	ERROR:    "ERROR",
@@ -80,10 +84,16 @@ func SetFileFlag(flag int) {
 	lock.WLockFunc(func() { fileflag = flag })
 }
 
-// SetFileMode sets the mode when open logging files. It is os.O_WRONLY |
+// SetFilePerm sets the mode when open logging files. It is os.O_WRONLY |
 // os.O_APPEND | os.O_CREATE by default.
 func SetFilePerm(perm fs.FileMode) {
 	lock.WLockFunc(func() { fileperm = perm })
+}
+
+// SetSkipCall sets the new skipCall value which dertermine the depth call of
+// Logger.log method.
+func SetSkipCall(skip int) {
+	lock.WLockFunc(func() { skipCall = skip })
 }
 
 // SetTimeLayout sets the time layout to print asctime. It is time.RFC3339Nano

--- a/xylog/config_test.go
+++ b/xylog/config_test.go
@@ -1,6 +1,7 @@
 package xylog_test
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -54,5 +55,23 @@ func TestSetTimeLayout(t *testing.T) {
 	xycond.MustNotPanic(func() {
 		xylog.SetTimeLayout("123")
 		xylog.SetTimeLayout(time.RFC3339Nano)
+	}).Test(t, "A panic occurred")
+}
+
+func TestSetFileFlag(t *testing.T) {
+	xycond.MustNotPanic(func() {
+		xylog.SetFileFlag(os.O_WRONLY | os.O_APPEND | os.O_CREATE)
+	}).Test(t, "A panic occurred")
+}
+
+func TestSetFilePerm(t *testing.T) {
+	xycond.MustNotPanic(func() {
+		xylog.SetFilePerm(0666)
+	}).Test(t, "A panic occurred")
+}
+
+func TestSetSkipCall(t *testing.T) {
+	xycond.MustNotPanic(func() {
+		xylog.SetSkipCall(2)
 	}).Test(t, "A panic occurred")
 }

--- a/xylog/event_logger.go
+++ b/xylog/event_logger.go
@@ -1,0 +1,82 @@
+package xylog
+
+import "fmt"
+
+// EventLogger is a logger wrapper supporting to compose logging message with
+// key-value pair.
+type EventLogger struct {
+	fields map[string]any
+	lg     *Logger
+}
+
+// Field adds a key-value pair to logging message.
+func (e *EventLogger) Field(key string, value any) *EventLogger {
+	e.fields[key] = value
+	return e
+}
+
+// compose creates the final logging messages from fields.
+func (e *EventLogger) compose() string {
+	var s = ""
+	for k, v := range e.fields {
+		s = prefixMessage(s, k+"="+fmt.Sprint(v))
+	}
+	return s
+}
+
+// Debug calls Log with DEBUG level.
+func (e *EventLogger) Debug() {
+	if e.lg.isEnabledFor(DEBUG) {
+		e.lg.log(DEBUG, e.compose())
+	}
+}
+
+// Info calls Log with INFO level.
+func (e *EventLogger) Info() {
+	if e.lg.isEnabledFor(INFO) {
+		e.lg.log(INFO, e.compose())
+	}
+}
+
+// Warn calls Log with WARN level.
+func (e *EventLogger) Warn() {
+	if e.lg.isEnabledFor(WARN) {
+		e.lg.log(WARN, e.compose())
+	}
+}
+
+// Warning calls Log with WARNING level.
+func (e *EventLogger) Warning() {
+	if e.lg.isEnabledFor(WARNING) {
+		e.lg.log(WARNING, e.compose())
+	}
+}
+
+// Error calls Log with ERROR level.
+func (e *EventLogger) Error() {
+	if e.lg.isEnabledFor(ERROR) {
+		e.lg.log(ERROR, e.compose())
+	}
+}
+
+// Fatal calls Log with FATAL level.
+func (e *EventLogger) Fatal() {
+	if e.lg.isEnabledFor(FATAL) {
+		e.lg.log(FATAL, e.compose())
+	}
+}
+
+// Critical calls Log with CRITICAL level.
+func (e *EventLogger) Critical() {
+	if e.lg.isEnabledFor(CRITICAL) {
+		e.lg.log(CRITICAL, e.compose())
+	}
+}
+
+// Log logs with a custom level.
+func (e *EventLogger) Log(level int) {
+	level = checkLevel(level)
+	if e.lg.isEnabledFor(level) {
+		e.lg.log(level, e.compose())
+	}
+}

--- a/xylog/event_logger_test.go
+++ b/xylog/event_logger_test.go
@@ -1,0 +1,25 @@
+package xylog_test
+
+import (
+	"testing"
+
+	"github.com/xybor/xyplatform/xycond"
+	"github.com/xybor/xyplatform/xylog"
+)
+
+func TestNewEventLogger(t *testing.T) {
+	var logger = xylog.GetLogger(t.Name())
+	logger.SetLevel(xylog.DEBUG)
+	xycond.MustNotPanic(func() {
+		var elogger = logger.Event("event")
+		elogger.Field("foo", "bar")
+		elogger.Debug()
+		elogger.Info()
+		elogger.Warn()
+		elogger.Warning()
+		elogger.Error()
+		elogger.Fatal()
+		elogger.Critical()
+		elogger.Log(validCustomLevels[1])
+	}).Test(t, "A panic occurred")
+}

--- a/xylog/example_test.go
+++ b/xylog/example_test.go
@@ -37,10 +37,11 @@ func ExampleGetLogger() {
 	var logger = xylog.GetLogger("example")
 	logger.AddHandler(handler)
 	logger.SetLevel(xylog.DEBUG)
+	logger.AddExtra("some", "thing")
 	logger.Debug("foo %s", "bar")
 
 	// Output:
-	// module=example level=DEBUG foo bar
+	// module=example level=DEBUG some=thing foo bar
 }
 
 func ExampleHandler() {
@@ -134,4 +135,18 @@ func ExampleNewTimeRotatingFileEmitter() {
 	// Created exampleTime.log
 	// Created exampleTime.log.1
 	// Created exampleTime.log.2
+}
+
+func ExampleEventLogger() {
+	var handler = xylog.NewHandler("", xylog.NewStreamEmitter(os.Stdout))
+	handler.SetFormatter(xylog.NewTextFormatter(
+		"module=%(name)s level=%(levelname)s %(message)s"))
+
+	var logger = xylog.GetLogger("eventlogger")
+	logger.AddHandler(handler)
+	logger.SetLevel(xylog.DEBUG)
+	logger.Event("create").Field("product", 1235).Debug()
+
+	// Output:
+	// module=eventlogger level=DEBUG event=create product=1235
 }

--- a/xylog/formatter.go
+++ b/xylog/formatter.go
@@ -18,7 +18,7 @@ type Formatter interface {
 // The TextFormatter can be initialized with a format string which makes use of
 // knowledge of the LogRecord attributes - e.g. %(message)s or %(levelno)d. See
 // LogRecord for more details.
-type textFormatter struct {
+type TextFormatter struct {
 	formatstring  string
 	attrbuteIndex []int
 }
@@ -26,7 +26,7 @@ type textFormatter struct {
 // NewTextFormatter creates a textFormatter which uses LogRecord attributes to
 // contribute logging string, e.g. %(message)s or %(levelno)d. See LogRecord for
 // more details.
-func NewTextFormatter(s string) textFormatter {
+func NewTextFormatter(s string) TextFormatter {
 	var record = LogRecord{}
 	var attributeIndex []int
 	var fmtstr = ""
@@ -57,14 +57,15 @@ func NewTextFormatter(s string) textFormatter {
 		i++
 	}
 
-	return textFormatter{
+	return TextFormatter{
 		formatstring:  fmtstr,
 		attrbuteIndex: attributeIndex,
 	}
 }
 
-// Format creates a logging string by combine format string and logging record.
-func (f textFormatter) Format(record LogRecord) string {
+// Format creates a logging string by combining format string and logging
+// record.
+func (f TextFormatter) Format(record LogRecord) string {
 	var attrs = make([]any, len(f.attrbuteIndex))
 	for i := range f.attrbuteIndex {
 		attrs[i] = record.mapIndex(f.attrbuteIndex[i])

--- a/xylog/logger.go
+++ b/xylog/logger.go
@@ -29,6 +29,7 @@ type Logger struct {
 	handlers []*Handler
 	lock     xylock.RWLock
 	cache    map[int]bool
+	extra    string
 }
 
 // newlogger creates a new logger with a name and parent. The fullname of logger
@@ -50,6 +51,7 @@ func newlogger(name string, parent *Logger) *Logger {
 		handlers: nil,
 		lock:     xylock.RWLock{},
 		cache:    make(map[int]bool),
+		extra:    "",
 	}
 }
 
@@ -98,6 +100,11 @@ func (lg *Logger) GetFilters() []Filter {
 	return lg.f.GetFilters()
 }
 
+func (lg *Logger) AddExtra(key string, value any) {
+	var extra = key + "=" + fmt.Sprint(value)
+	lg.extra = prefixMessage(lg.extra, extra)
+}
+
 // filter checks all filters in filterer, if there is any failed filter, it will
 // returns false.
 func (lg *Logger) filter(r LogRecord) bool {
@@ -105,66 +112,75 @@ func (lg *Logger) filter(r LogRecord) bool {
 }
 
 // Debug calls Log with DEBUG level.
-func (lg *Logger) Debug(msg string, a ...any) {
+func (lg *Logger) Debug(s string, a ...any) {
 	if lg.isEnabledFor(DEBUG) {
-		lg.log(DEBUG, fmt.Sprintf(msg, a...))
+		lg.log(DEBUG, fmt.Sprintf(s, a...))
 	}
 }
 
 // Info calls Log with INFO level.
-func (lg *Logger) Info(msg string, a ...any) {
+func (lg *Logger) Info(s string, a ...any) {
 	if lg.isEnabledFor(INFO) {
-		lg.log(INFO, fmt.Sprintf(msg, a...))
+		lg.log(INFO, s, a...)
 	}
 }
 
 // Warn calls Log with WARN level.
-func (lg *Logger) Warn(msg string, a ...any) {
+func (lg *Logger) Warn(s string, a ...any) {
 	if lg.isEnabledFor(WARN) {
-		lg.log(WARN, fmt.Sprintf(msg, a...))
+		lg.log(WARN, s, a...)
 	}
 }
 
 // Warning calls Log with WARNING level.
-func (lg *Logger) Warning(msg string, a ...any) {
+func (lg *Logger) Warning(s string, a ...any) {
 	if lg.isEnabledFor(WARNING) {
-		lg.log(WARNING, fmt.Sprintf(msg, a...))
+		lg.log(WARNING, s, a...)
 	}
 }
 
 // Error calls Log with ERROR level.
-func (lg *Logger) Error(msg string, a ...any) {
+func (lg *Logger) Error(s string, a ...any) {
 	if lg.isEnabledFor(ERROR) {
-		lg.log(ERROR, fmt.Sprintf(msg, a...))
+		lg.log(ERROR, s, a...)
 	}
 }
 
 // Fatal calls Log with FATAL level.
-func (lg *Logger) Fatal(msg string, a ...any) {
+func (lg *Logger) Fatal(s string, a ...any) {
 	if lg.isEnabledFor(FATAL) {
-		lg.log(FATAL, fmt.Sprintf(msg, a...))
+		lg.log(FATAL, s, a...)
 	}
 }
 
 // Critical calls Log with CRITICAL level.
-func (lg *Logger) Critical(msg string, a ...any) {
+func (lg *Logger) Critical(s string, a ...any) {
 	if lg.isEnabledFor(CRITICAL) {
-		lg.log(CRITICAL, fmt.Sprintf(msg, a...))
+		lg.log(CRITICAL, s, a...)
 	}
 }
 
 // Log logs a message with a custom level.
-func (lg *Logger) Log(level int, msg string, a ...any) {
+func (lg *Logger) Log(level int, s string, a ...any) {
 	level = checkLevel(level)
 	if lg.isEnabledFor(level) {
-		lg.log(level, fmt.Sprintf(msg, a...))
+		lg.log(level, s, a...)
+	}
+}
+
+// Event creates an eventLogger which logs key-value pairs.
+func (lg *Logger) Event(e string) *EventLogger {
+	return &EventLogger{
+		lg:     lg,
+		fields: map[string]any{"event": e},
 	}
 }
 
 // log is a low-level logging method which creates a LogRecord and then calls
 // all the handlers of this logger to handle the record.
-func (lg *Logger) log(level int, msg string) {
-	var pc, filename, lineno, ok = runtime.Caller(2)
+func (lg *Logger) log(level int, s string, a ...any) {
+	var msg = prefixMessage(lg.extra, fmt.Sprintf(s, a...))
+	var pc, filename, lineno, ok = runtime.Caller(skipCall)
 	if !ok {
 		filename = "unknown"
 		lineno = -1
@@ -240,4 +256,12 @@ func (lg *Logger) clearCache() {
 	for i := range lg.children {
 		lg.children[i].clearCache()
 	}
+}
+
+// prefixMessage adds a prefix to origin message if the prefix is not empty.
+func prefixMessage(prefix, msg string) string {
+	if prefix != "" {
+		msg = fmt.Sprintf("%s %s", prefix, msg)
+	}
+	return msg
 }

--- a/xylog/logger_test.go
+++ b/xylog/logger_test.go
@@ -213,3 +213,16 @@ func TestLoggerFilterLog(t *testing.T) {
 	xycond.MustEmpty(capturedOutput).
 		Testf(t, "Expected an empty output, but got %s", capturedOutput)
 }
+
+func TestLoggerAddExtra(t *testing.T) {
+	var handler = xylog.NewHandler("", &CapturedEmitter{})
+	var logger = xylog.GetLogger(t.Name())
+	logger.SetLevel(xylog.DEBUG)
+	logger.AddHandler(handler)
+	logger.AddExtra("bar", "something")
+
+	capturedOutput = ""
+	logger.Info("foo")
+	xycond.MustEqual(capturedOutput, "bar=something foo").
+		Testf(t, "%s != %s", capturedOutput, "bar=something foo")
+}


### PR DESCRIPTION
The new logging format is more readable and should be applied to xylog.
`key1=value1 key2=value2`

xylog should allow to add custom string to all logging messages of a module.
It is helpful when a specified module is using a common information, but all of them are using only one handler with a fixed formatter.