### PR TITLE
PLF-79 Misspelling in cron_test.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![GitHub release (release name instead of tag name)](https://img.shields.io/github/v/release/xybor/xyplatform?include_prereleases)](https://github.com/xybor/xyplatform/releases/latest)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/34ed76ef9cef4d67aa5c687945b6bdf0)](https://www.codacy.com/gh/xybor/xyplatform/dashboard?utm_source=github.com&utm_medium=referral&utm_content=xybor/xyplatform&utm_campaign=Badge_Grade)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/34ed76ef9cef4d67aa5c687945b6bdf0)](https://www.codacy.com/gh/xybor/xyplatform/dashboard?utm_source=github.com&utm_medium=referral&utm_content=xybor/xyplatform&utm_campaign=Badge_Coverage)
+[![Go Report](https://goreportcard.com/badge/github.com/xybor/xyplatform)](https://goreportcard.com/report/github.com/xybor/xyplatform)
 
 Xyplatform contains platform libraries developed by Xybor.
 

--- a/xylog/logger_test.go
+++ b/xylog/logger_test.go
@@ -83,9 +83,8 @@ func TestLoggerAddHandlerNil(t *testing.T) {
 func TestLoggerRemoveInvalidHandler(t *testing.T) {
 	var expectedHandler = xylog.NewHandler("", &CapturedEmitter{})
 	var logger = xylog.GetLogger(t.Name())
-	var handlers = logger.GetHandlers()
 	logger.RemoveHandler(expectedHandler)
-	handlers = logger.GetHandlers()
+	var handlers = logger.GetHandlers()
 	xycond.MustEmpty(handlers).
 		Testf(t, "Expected no handler, but got %d", len(handlers))
 }

--- a/xysched/cron_test.go
+++ b/xysched/cron_test.go
@@ -53,7 +53,7 @@ func TestCronPeriodic(t *testing.T) {
 
 	xycond.MustNotPanic(func() {
 		c.Every(3 * time.Hour)
-	}).Test(t, "A panic occured")
+	}).Test(t, "A panic occurred")
 
 	xycond.MustPanic(func() {
 		c.Every(-3 * time.Hour)
@@ -65,19 +65,19 @@ func TestCronMacroPeriodic(t *testing.T) {
 
 	xycond.MustNotPanic(func() {
 		c.Secondly()
-	}).Test(t, "A panic occured")
+	}).Test(t, "A panic occurred")
 
 	xycond.MustNotPanic(func() {
 		c.Minutely()
-	}).Test(t, "A panic occured")
+	}).Test(t, "A panic occurred")
 
 	xycond.MustNotPanic(func() {
 		c.Hourly()
-	}).Test(t, "A panic occured")
+	}).Test(t, "A panic occurred")
 
 	xycond.MustNotPanic(func() {
 		c.Daily()
-	}).Test(t, "A panic occured")
+	}).Test(t, "A panic occurred")
 }
 
 func TestCronTimes(t *testing.T) {
@@ -85,7 +85,7 @@ func TestCronTimes(t *testing.T) {
 
 	xycond.MustNotPanic(func() {
 		c.Times(5)
-	}).Test(t, "A panic occured")
+	}).Test(t, "A panic occurred")
 }
 
 func TestCronMacroTimes(t *testing.T) {
@@ -93,11 +93,11 @@ func TestCronMacroTimes(t *testing.T) {
 
 	xycond.MustNotPanic(func() {
 		c.Once()
-	}).Test(t, "A panic occured")
+	}).Test(t, "A panic occurred")
 
 	xycond.MustNotPanic(func() {
 		c.Twice()
-	}).Test(t, "A panic occured")
+	}).Test(t, "A panic occurred")
 }
 
 func TestCronFinish(t *testing.T) {


### PR DESCRIPTION
Add go report card https://goreportcard.com/report/github.com/xybor/xyplatform to README.md.

Fix misspelling.