### PR TITLE
PLF-74 Identify scheduler by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 1.  Add FileEmitter and RotatingFileEmitter to xylog.
 2.  Xylog now can be easy to use key-value fields and extra values.
-3.  Add Codacy analysis.
+3.  Add report analysis badges.
+4.  Reduce logging time.
+5.  Refactor xycond to be shorter and more readable.
+6.  Scheduler now can be identified by name.
 
-# V1.0.1
+# V0.0.2
 
 1.  Fix bugs.
 2.  Refactor the design of xylog Handler.
@@ -12,18 +15,18 @@
 4.  Write unittest for all modules.
 5.  Xycond asserts a Error instead of string.
 
-# V1.0.0
+# V0.0.1
 
 This release completed the following libraries:
 
 1.  xycond supports to check many types of condition and panic if the condition
-fails.
+    fails.
 
 2.  xyerror contains special errors that are good for error comparison and
-debugging.
+    debugging.
 
 3.  xylock contains wrapper structs of built-in sync library, such as
-`sync.Mutex` or `semaphore.Weighted`.
+    `sync.Mutex` or `semaphore.Weighted`.
 
 4.  xylog provides flexible logging methods to the program.
 

--- a/README.md
+++ b/README.md
@@ -30,5 +30,3 @@ details.
     syntax.
 
 6.  Package [xyselect](./xyselect) defines custom select statements.
-
-_NOTE: All version 1.0.x are unstable._

--- a/xylog/README.md
+++ b/xylog/README.md
@@ -2,8 +2,6 @@
 
 Package xylog is a logging module based on the design of python logging
 
-This package is inspired by idea of Python `logging`.
-
 # Feature
 
 The basic structs defined by the module, together with their functions, are

--- a/xysched/README.md
+++ b/xysched/README.md
@@ -91,11 +91,16 @@ future.Catch(func(e error) { fmt.Println(e) })
 xysched.Now() <- future
 ```
 
-6.  Create a new scheduler if it is necessary.
+6.  Create a new scheduler if it is necessary. Scheduler with non-empty name can
+    be used in many places without a global variable.
 
 ```golang
-var scheduler = xysched.New()
+// a.go
+var scheduler = xysched.NewScheduler("foo")
 scheduler.After(3 * time.Second) <- xysched.NewTask(fmt.Println, "x")
+
+// b.go
+var scheduler = xysched.GetScheduler("foo")
 
 // A scheduler should be stopped if it won't be used anymore.
 scheduler.Stop()

--- a/xysched/example_test.go
+++ b/xysched/example_test.go
@@ -37,7 +37,7 @@ func Example() {
 }
 
 func ExampleTask() {
-	var scheduler = xysched.NewScheduler()
+	var scheduler = xysched.NewScheduler("")
 
 	// Example 1: Task is a simple future used for scheduling to run a function.
 	var done = make(chan any)
@@ -99,7 +99,7 @@ func wait(c chan any, n int) {
 }
 
 func ExampleCron() {
-	var scheduler = xysched.NewScheduler()
+	var scheduler = xysched.NewScheduler("")
 	// Example 1: Cron is a future which runs function periodically. By default,
 	// it runs secondly forever.
 	var done = make(chan any)
@@ -111,7 +111,7 @@ func ExampleCron() {
 	wait(done, 2)
 	scheduler.Stop()
 
-	scheduler = xysched.NewScheduler()
+	scheduler = xysched.NewScheduler("")
 	// Example 2: It can modify periodic duration and the maximum times the
 	// function could run.
 	done = make(chan any)

--- a/xysched/global.go
+++ b/xysched/global.go
@@ -6,7 +6,7 @@ import (
 )
 
 // A default scheduler.
-var global = NewScheduler()
+var global = NewScheduler("")
 
 // After creates a send-only channel. Sending a future to this channel will
 // add it to scheduler after a duration. If d is negative, After will send the

--- a/xysched/scheduler_test.go
+++ b/xysched/scheduler_test.go
@@ -9,14 +9,13 @@ import (
 )
 
 func TestNewScheduler(t *testing.T) {
-	xycond.ExpectNotPanic(func() {
-		var sched = xysched.NewScheduler()
-		sched.Stop()
-	}).Test(t)
+	var sched = xysched.NewScheduler(t.Name())
+	xycond.ExpectEqual(sched, xysched.GetScheduler(t.Name())).Test(t)
+	defer sched.Stop()
 }
 
 func TestSchedulerAfter(t *testing.T) {
-	var sched = xysched.NewScheduler()
+	var sched = xysched.NewScheduler("")
 	defer sched.Stop()
 
 	xycond.ExpectNotPanic(func() {
@@ -26,7 +25,7 @@ func TestSchedulerAfter(t *testing.T) {
 }
 
 func TestSchedulerAfterButCloseSoon(t *testing.T) {
-	var sched = xysched.NewScheduler()
+	var sched = xysched.NewScheduler("")
 
 	xycond.ExpectNotPanic(func() {
 		sched.After(time.Second) <- xysched.NewTask(func() {})
@@ -36,7 +35,7 @@ func TestSchedulerAfterButCloseSoon(t *testing.T) {
 }
 
 func TestSchedulerAfterWithNegativeDuration(t *testing.T) {
-	var sched = xysched.NewScheduler()
+	var sched = xysched.NewScheduler("")
 	defer sched.Stop()
 
 	xycond.ExpectNotPanic(func() {
@@ -45,7 +44,7 @@ func TestSchedulerAfterWithNegativeDuration(t *testing.T) {
 }
 
 func TestSchedulerAfterMacros(t *testing.T) {
-	var sched = xysched.NewScheduler()
+	var sched = xysched.NewScheduler("")
 	defer sched.Stop()
 
 	xycond.ExpectNotPanic(func() {
@@ -58,7 +57,7 @@ func TestSchedulerAfterMacros(t *testing.T) {
 }
 
 func TestSchedulerConcurrent(t *testing.T) {
-	var sched = xysched.NewScheduler()
+	var sched = xysched.NewScheduler("")
 	defer sched.Stop()
 
 	xycond.ExpectNotPanic(func() {


### PR DESCRIPTION
#### Issue

-   https://xybor.atlassian.net/browse/PLF-74

#### Description

Schedulers can be used in many modules. So we need a method to get the scheduler by its name.

#### Changes

-   [ ] Fix bug
-   [x] New feature
-   [x] Documentation
-   [x] Backward incompatible change

#### Testing

-   Unittests.

#### Checklist

-   [x] Modify README.md.
-   [x] Modify CHANGELOG.md
-   [x] Modify comments.
