### PR TITLE
PLF-83 Lock emitter before it emits

### DIFF
--- a/xylog/handler.go
+++ b/xylog/handler.go
@@ -70,6 +70,6 @@ func (h *Handler) filter(r LogRecord) bool {
 func (h *Handler) handle(record LogRecord) {
 	var level = h.lock.RLockFunc(func() any { return h.level }).(int)
 	if h.filter(record) && record.LevelNo >= level {
-		h.e.Emit(record)
+		h.lock.WLockFunc(func() { h.e.Emit(record) })
 	}
 }


### PR DESCRIPTION
#### Issue

-   https://xybor.atlassian.net/browse/PLF-83

#### Description

-   Problem: While testing, I detected handler doesn’t lock while call emitter.
-   Solution: Lock handler while emitting.
#### Changes

-   [x] Fix bug
-   [ ] New feature
-   [ ] Documentation
-   [ ] Backward incompatible change

#### Testing

-   No suitable test.

#### Checklist

-   [x] Modify README.md.
-   [x] Modify CHANGELOG.md
-   [x] Modify comments.
