### PR TITLE
PLF-87 Combine get and new methods of Schedulers into one

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,6 @@
 
 #### Checklist
 
--   [ ] Modify README.md.
--   [ ] Modify CHANGELOG.md
--   [ ] Modify comments.
+-   [ ] Check README.md.
+-   [ ] Check CHANGELOG.md
+-   [ ] Check comments.

--- a/xylog/handler.go
+++ b/xylog/handler.go
@@ -18,7 +18,7 @@ type Handler struct {
 
 // NewHandler creates a Handler with a specified Emitter.
 //
-// Any Handler with a not-empty name will be associated with its name. Calling
+// Any Handler with a non-empty name will be associated with its name. Calling
 // NewHandler twice with the same name will cause a panic. If you want to create
 // an anonymous Handler, call this function with an empty name.
 func NewHandler(name string, e Emitter) *Handler {

--- a/xysched/example_test.go
+++ b/xysched/example_test.go
@@ -38,6 +38,7 @@ func Example() {
 
 func ExampleTask() {
 	var scheduler = xysched.NewScheduler("")
+	defer scheduler.Stop()
 
 	// Example 1: Task is a simple future used for scheduling to run a function.
 	var done = make(chan any)
@@ -83,8 +84,6 @@ func ExampleTask() {
 	scheduler.Now() <- future
 	<-done
 
-	scheduler.Stop()
-
 	// Output:
 	// 1. foo
 	// 2. foo foo
@@ -112,6 +111,7 @@ func ExampleCron() {
 	scheduler.Stop()
 
 	scheduler = xysched.NewScheduler("")
+	defer scheduler.Stop()
 	// Example 2: It can modify periodic duration and the maximum times the
 	// function could run.
 	done = make(chan any)
@@ -136,8 +136,6 @@ func ExampleCron() {
 	future.Finish(func() { close(done) })
 	scheduler.Now() <- future
 	wait(done, 1)
-
-	scheduler.Stop()
 
 	// Output:
 	// 1. foo bar

--- a/xysched/global.go
+++ b/xysched/global.go
@@ -3,7 +3,17 @@ package xysched
 
 import (
 	"time"
+
+	"github.com/xybor/xyplatform/xylock"
 )
+
+func init() {
+	schedulerManager = make(map[string]*Scheduler)
+}
+
+// schedulerManager stores Schedulers with their names.
+var schedulerManager map[string]*Scheduler
+var lock = xylock.RWLock{}
 
 // A default scheduler.
 var global = NewScheduler("")

--- a/xysched/scheduler_test.go
+++ b/xysched/scheduler_test.go
@@ -10,8 +10,10 @@ import (
 
 func TestNewScheduler(t *testing.T) {
 	var sched = xysched.NewScheduler(t.Name())
-	xycond.ExpectEqual(sched, xysched.GetScheduler(t.Name())).Test(t)
-	defer sched.Stop()
+	xycond.ExpectEqual(sched, xysched.NewScheduler(t.Name())).Test(t)
+
+	sched = xysched.NewScheduler("")
+	xycond.ExpectNotEqual(sched, xysched.NewScheduler("")).Test(t)
 }
 
 func TestSchedulerAfter(t *testing.T) {


### PR DESCRIPTION
#### Issue

-   https://xybor.atlassian.net/browse/PLF-87

#### Description

-   `GetScheduler` and `NewScheduler` are two methods to get a Scheduler. It should be combines into one.

#### Changes

-   [ ] Fix bug
-   [ ] New feature
-   [ ] Documentation
-   [x] Backward incompatible change

#### Testing

-   No new test.

#### Checklist

-   [x] Modify README.md.
-   [x] Modify CHANGELOG.md
-   [x] Modify comments.
