### PR TITLE
PLF-86 Allow future to early stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 5.  Refactor xycond to be shorter and more readable.
 6.  Scheduler now can be identified by name.
 7.  Add log to xysched and xyselect.
+8.  Future now can early stop.
 
 # V0.0.2
 

--- a/xysched/README.md
+++ b/xysched/README.md
@@ -97,6 +97,7 @@ xysched.Now() <- future
 ```golang
 // a.go
 var scheduler = xysched.NewScheduler("foo")
+defer sched.Stop()
 scheduler.After(3 * time.Second) <- xysched.NewTask(fmt.Println, "x")
 
 // b.go
@@ -104,4 +105,19 @@ var scheduler = xysched.GetScheduler("foo")
 
 // A scheduler should be stopped if it won't be used anymore.
 scheduler.Stop()
+```
+
+7.  Early stop a future.
+
+```golang
+var sched = xysched.NewScheduler("")
+defer sched.Stop()
+
+var captured string
+var task = xysched.NewTask(func() { captured = "run" })
+sched.After(time.Millisecond) <- task
+task.Stop()
+
+time.Sleep(2 * time.Millisecond)
+xycond.AssertEmpty(captured)
 ```

--- a/xysched/cron.go
+++ b/xysched/cron.go
@@ -89,6 +89,13 @@ func (c *Cron) Finish(f any, params ...any) *Task {
 	return nil
 }
 
+// Stop early stops the Cron. If the Cron hasn't been scheduled yet, it will be
+// never scheduled. If the Cron was scheduled, next runs will be canceled.
+func (c *Cron) Stop() {
+	c.Task.Stop()
+	c.lock.LockFunc(func() { c.n = 0 })
+}
+
 // String supports to print the task to output.
 func (c *Cron) String() string {
 	var n = c.lock.RLockFunc(func() any { return c.n }).(uint)

--- a/xysched/cron_test.go
+++ b/xysched/cron_test.go
@@ -124,3 +124,18 @@ func TestCronFinish(t *testing.T) {
 		cron.Finish(callback, 1, 2)
 	}).Test(t)
 }
+
+func TestCronStop(t *testing.T) {
+	var sched = xysched.NewScheduler("")
+	defer sched.Stop()
+
+	var captured int
+	var cron = xysched.NewCron(func() { captured++ })
+	cron.Every(time.Millisecond)
+	cron.Times(10)
+	sched.Now() <- cron
+	cron.Stop()
+	time.Sleep(time.Second)
+
+	xycond.ExpectLessThan(captured, 10).Test(t)
+}

--- a/xysched/example_test.go
+++ b/xysched/example_test.go
@@ -28,7 +28,7 @@ func Example() {
 		fmt.Println("2. barfoo")
 		close(done)
 	})
-	xysched.After(time.Second) <- future
+	xysched.After(time.Millisecond) <- future
 	<-done
 
 	// Output:
@@ -118,13 +118,14 @@ func ExampleCron() {
 	future = xysched.NewCron(func() {
 		fmt.Println("2. bar bar")
 		done <- nil
-	}).Every(1 * time.Millisecond).Twice()
+	}).Every(time.Millisecond).Twice()
 	scheduler.Now() <- future
 	wait(done, 2)
 
 	// Example 3: Callback, Then, Catch can also be used on cron.
 	done = make(chan any)
 	future = xysched.NewCron(fmt.Println, "3.", "foobar").Times(3)
+	future.Every(time.Millisecond)
 	future.Callback(func() { done <- nil })
 	scheduler.Now() <- future
 	wait(done, 3)
@@ -133,6 +134,7 @@ func ExampleCron() {
 	// out of times.
 	done = make(chan any)
 	future = xysched.NewCron(fmt.Println, "4.", "foobar").Twice()
+	future.Every(time.Millisecond)
 	future.Finish(func() { close(done) })
 	scheduler.Now() <- future
 	wait(done, 1)

--- a/xysched/task_test.go
+++ b/xysched/task_test.go
@@ -2,6 +2,7 @@ package xysched_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/xybor/xyplatform/xycond"
 	"github.com/xybor/xyplatform/xysched"
@@ -98,4 +99,17 @@ func TestTaskCatch(t *testing.T) {
 	xycond.ExpectPanic(func() {
 		task.Catch(func() {})
 	}).Test(t)
+}
+
+func TestTaskStop(t *testing.T) {
+	var sched = xysched.NewScheduler("")
+	defer sched.Stop()
+
+	var captured string
+	var task = xysched.NewTask(func() { captured = "run" })
+	sched.After(time.Millisecond) <- task
+	task.Stop()
+
+	time.Sleep(2 * time.Millisecond)
+	xycond.ExpectEmpty(captured).Test(t)
 }


### PR DESCRIPTION
#### Issue

-   https://xybor.atlassian.net/browse/PLF-86

#### Description

-   Sometimes future doesn’t need to schedule anymore. So it makes sense to create a early stop feature for future.

#### Changes

-   [ ] Fix bug
-   [x] New feature
-   [ ] Documentation
-   [ ] Backward incompatible change

#### Testing

-   Unittest.

#### Checklist

-   [x] Check README.md.
-   [x] Check CHANGELOG.md
-   [x] Check comments.
