### PR TITLE
PLF-76 Split format and non-format of methods with string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 6.  Scheduler now can be identified by name.
 7.  Add log to xysched and xyselect.
 8.  Future now can early stop.
+9.  Methods with formatting string are splitted to two seperated methods (with f
+    and non-f suffix).
 
 # V0.0.2
 

--- a/xycond/condition.go
+++ b/xycond/condition.go
@@ -257,7 +257,7 @@ func ExpectFalse(b bool) Condition {
 
 // Panic panics with a formatted string.
 func Panic(msg string, a ...any) {
-	panic(xyerror.AssertionError.New(msg, a...))
+	panic(xyerror.AssertionError.Newf(msg, a...))
 }
 
 // JustPanic panics immediately.

--- a/xyerror/README.md
+++ b/xyerror/README.md
@@ -158,7 +158,7 @@ func ExampleXyError() {
 		fmt.Println("err1 is not a NegativeIndexError")
 	}
 
-	var err2 = NegativeIndexError.New("some negative index error")
+	var err2 = NegativeIndexError.Newf("some negative index error %d", -1)
 	if errors.Is(err2, NegativeIndexError) {
 		fmt.Println("err2 is a NegativeIndexError")
 	}

--- a/xyerror/class.go
+++ b/xyerror/class.go
@@ -51,9 +51,14 @@ func (c Class) NewClassM(gen Generator) Class {
 	return class
 }
 
-// New creates a XyError with an error message.
-func (c Class) New(msg string, a ...any) XyError {
+// Newf creates a XyError with a formatting message.
+func (c Class) Newf(msg string, a ...any) XyError {
 	return XyError{c: c, msg: fmt.Sprintf(msg, a...)}
+}
+
+// Newf creates a XyError with default formatting objects.
+func (c Class) New(a ...any) XyError {
+	return XyError{c: c, msg: fmt.Sprint(a...)}
 }
 
 // belongsTo checks if a Class is inherited from a target class. A class belongs

--- a/xyerror/error_test.go
+++ b/xyerror/error_test.go
@@ -11,8 +11,11 @@ func TestXyError(t *testing.T) {
 	var id = nextid()
 	var egen = xyerror.Register("", id)
 	var c = egen.NewClass("class")
-	var xerr = c.New("error")
-	xycond.ExpectEqual(xerr.Error(), "class: error").Test(t)
+	var xerr1 = c.Newf("error-%d", 1)
+	var xerr2 = c.New("error-2")
+
+	xycond.ExpectEqual(xerr1.Error(), "class: error-1").Test(t)
+	xycond.ExpectEqual(xerr2.Error(), "class: error-2").Test(t)
 }
 
 func TestXyErrorIs(t *testing.T) {

--- a/xyerror/example_test.go
+++ b/xyerror/example_test.go
@@ -37,7 +37,7 @@ func ExampleXyError() {
 		fmt.Println("err1 is not a NegativeIndexError")
 	}
 
-	var err2 = NegativeIndexError.New("some negative index error")
+	var err2 = NegativeIndexError.Newf("some negative index error %d", -1)
 	if errors.Is(err2, NegativeIndexError) {
 		fmt.Println("err2 is a NegativeIndexError")
 	}

--- a/xylog/README.md
+++ b/xylog/README.md
@@ -24,17 +24,14 @@ Loggers should NEVER be instantiated directly, but always through the
 module-level function `xylog.GetLogger(name)`. Multiple calls to `GetLogger()`
 with the same name will always return a reference to the same Logger object.
 
-You can logs a message by using one of the following methods:
+You can logs a message by using one of built-in logging methods, such as:
 
 ```golang
-func (*Logger) Critical(msg string, a ...any)
-func (*Logger) Error(msg string, a ...any)
-func (*Logger) Fatal(msg string, a ...any)
-func (*Logger) Warn(msg string, a ...any)
-func (*Logger) Warning(msg string, a ...any)
-func (*Logger) Info(msg string, a ...any)
-func (*Logger) Debug(msg string, a ...any)
-func (*Logger) Log(level int, msg string, a ...any)
+func Log(level int, a ...any)
+func Logf(level int, msg string, a ...any)
+
+func Debug(a ...any)
+func Debugf(msg string, a ...any)
 ```
 
 To add `Handler` or `Filter` instances to the `logger`, call `AddHandler` or
@@ -278,9 +275,9 @@ import (
 var logger = xylog.GetLogger("xybor.xyplatform.foo")
 
 func main() {
-    logger.Debug("message=bar")
+    logger.Debug(1)
 }
 
 // Output:
-// time=[time] source=example.go.main:13 level=DEBUG module=foo message=bar
+// time=[time] source=example.go.main:13 level=DEBUG module=foo message=1
 ```

--- a/xylog/example_test.go
+++ b/xylog/example_test.go
@@ -24,9 +24,11 @@ func Example() {
 
 	xylog.AddHandler(handler)
 	xylog.Debug("foo")
+	xylog.Infof("foo %s", "bar")
 
 	// Output:
 	// foo
+	// foo bar
 }
 
 func ExampleGetLogger() {
@@ -38,7 +40,7 @@ func ExampleGetLogger() {
 	logger.AddHandler(handler)
 	logger.SetLevel(xylog.DEBUG)
 	logger.AddExtra("some", "thing")
-	logger.Debug("foo %s", "bar")
+	logger.Debugf("foo %s", "bar")
 
 	// Output:
 	// module=example level=DEBUG some=thing foo bar

--- a/xylog/handler_test.go
+++ b/xylog/handler_test.go
@@ -49,7 +49,7 @@ func TestHandlerFilterLog(t *testing.T) {
 		logger.AddHandler(handler)
 
 		capturedOutput = ""
-		logger.Info(expectedMessage)
+		logger.Warningf(expectedMessage)
 		if tests[i].filterName != t.Name() {
 			xycond.ExpectEmpty(capturedOutput).Test(t)
 		} else {
@@ -78,7 +78,7 @@ func TestHandlerLevel(t *testing.T) {
 		logger.SetLevel(xylog.DEBUG)
 		logger.AddHandler(handler)
 		capturedOutput = ""
-		logger.Log(loggerLevel, expectedMessage)
+		logger.Logf(loggerLevel, expectedMessage)
 		if loggerLevel < tests[i].level {
 			xycond.ExpectEmpty(capturedOutput).Test(t)
 		} else {

--- a/xylog/logger.go
+++ b/xylog/logger.go
@@ -100,60 +100,117 @@ func (lg *Logger) filter(r LogRecord) bool {
 	return lg.f.filter(r)
 }
 
-// Debug calls Log with DEBUG level.
-func (lg *Logger) Debug(s string, a ...any) {
+// Debug logs default formatting objects with DEBUG level.
+func (lg *Logger) Debug(a ...any) {
+	if lg.isEnabledFor(DEBUG) {
+		lg.log(DEBUG, fmt.Sprint(a...))
+	}
+}
+
+// Debugf logs a formatting message with DEBUG level.
+func (lg *Logger) Debugf(s string, a ...any) {
 	if lg.isEnabledFor(DEBUG) {
 		lg.log(DEBUG, fmt.Sprintf(s, a...))
 	}
 }
 
-// Info calls Log with INFO level.
-func (lg *Logger) Info(s string, a ...any) {
+// Info logs default formatting objects with INFO level.
+func (lg *Logger) Info(a ...any) {
 	if lg.isEnabledFor(INFO) {
-		lg.log(INFO, s, a...)
+		lg.log(INFO, fmt.Sprint(a...))
 	}
 }
 
-// Warn calls Log with WARN level.
-func (lg *Logger) Warn(s string, a ...any) {
+// Infof logs a formatting message with INFO level.
+func (lg *Logger) Infof(s string, a ...any) {
+	if lg.isEnabledFor(INFO) {
+		lg.log(INFO, fmt.Sprintf(s, a...))
+	}
+}
+
+// Warn logs default formatting objects with WARN level.
+func (lg *Logger) Warn(a ...any) {
 	if lg.isEnabledFor(WARN) {
-		lg.log(WARN, s, a...)
+		lg.log(WARN, fmt.Sprint(a...))
 	}
 }
 
-// Warning calls Log with WARNING level.
-func (lg *Logger) Warning(s string, a ...any) {
+// Warnf logs a formatting message with WARN level.
+func (lg *Logger) Warnf(s string, a ...any) {
+	if lg.isEnabledFor(WARN) {
+		lg.log(WARN, fmt.Sprintf(s, a...))
+	}
+}
+
+// Warning logs default formatting objects with WARNING level.
+func (lg *Logger) Warning(a ...any) {
 	if lg.isEnabledFor(WARNING) {
-		lg.log(WARNING, s, a...)
+		lg.log(WARNING, fmt.Sprint(a...))
 	}
 }
 
-// Error calls Log with ERROR level.
-func (lg *Logger) Error(s string, a ...any) {
+// Warningf logs a formatting message with WARNING level.
+func (lg *Logger) Warningf(s string, a ...any) {
+	if lg.isEnabledFor(WARNING) {
+		lg.log(WARNING, fmt.Sprintf(s, a...))
+	}
+}
+
+// Error logs default formatting objects with ERROR level.
+func (lg *Logger) Error(a ...any) {
 	if lg.isEnabledFor(ERROR) {
-		lg.log(ERROR, s, a...)
+		lg.log(ERROR, fmt.Sprint(a...))
 	}
 }
 
-// Fatal calls Log with FATAL level.
-func (lg *Logger) Fatal(s string, a ...any) {
+// Errorf logs a formatting message with ERROR level.
+func (lg *Logger) Errorf(s string, a ...any) {
+	if lg.isEnabledFor(ERROR) {
+		lg.log(ERROR, fmt.Sprintf(s, a...))
+	}
+}
+
+// Fatal logs default formatting objects with FATAL level.
+func (lg *Logger) Fatal(a ...any) {
 	if lg.isEnabledFor(FATAL) {
-		lg.log(FATAL, s, a...)
+		lg.log(FATAL, fmt.Sprint(a...))
 	}
 }
 
-// Critical calls Log with CRITICAL level.
-func (lg *Logger) Critical(s string, a ...any) {
+// Fatalf logs a formatting message with FATAL level.
+func (lg *Logger) Fatalf(s string, a ...any) {
+	if lg.isEnabledFor(FATAL) {
+		lg.log(FATAL, fmt.Sprintf(s, a...))
+	}
+}
+
+// Critical logs default formatting objects with CRITICAL level.
+func (lg *Logger) Critical(a ...any) {
 	if lg.isEnabledFor(CRITICAL) {
-		lg.log(CRITICAL, s, a...)
+		lg.log(CRITICAL, fmt.Sprint(a...))
 	}
 }
 
-// Log logs a message with a custom level.
-func (lg *Logger) Log(level int, s string, a ...any) {
+// Criticalf logs a formatting message with CRITICAL level.
+func (lg *Logger) Criticalf(s string, a ...any) {
+	if lg.isEnabledFor(CRITICAL) {
+		lg.log(CRITICAL, fmt.Sprintf(s, a...))
+	}
+}
+
+// Log logs default formatting objects with a custom level.
+func (lg *Logger) Log(level int, a ...any) {
 	level = checkLevel(level)
 	if lg.isEnabledFor(level) {
-		lg.log(level, s, a...)
+		lg.log(level, fmt.Sprint(a...))
+	}
+}
+
+// Logf logs a formatting message with a custom level.
+func (lg *Logger) Logf(level int, s string, a ...any) {
+	level = checkLevel(level)
+	if lg.isEnabledFor(level) {
+		lg.log(level, fmt.Sprintf(s, a...))
 	}
 }
 
@@ -165,8 +222,8 @@ func (lg *Logger) Event(e string) *EventLogger {
 
 // log is a low-level logging method which creates a LogRecord and then calls
 // all the handlers of this logger to handle the record.
-func (lg *Logger) log(level int, s string, a ...any) {
-	var msg = prefixMessage(lg.extra, fmt.Sprintf(s, a...))
+func (lg *Logger) log(level int, msg string) {
+	msg = prefixMessage(lg.extra, msg)
 	var pc, filename, lineno, ok = runtime.Caller(skipCall)
 	if !ok {
 		filename = "unknown"

--- a/xylog/root.go
+++ b/xylog/root.go
@@ -25,42 +25,82 @@ func SetLevel(level int) {
 	rootLogger.SetLevel(level)
 }
 
-// Log logs a message with a custom level by root logger.
-func Log(level int, msg string, a ...any) {
-	rootLogger.Log(level, msg, a...)
+// Debug logs default formatting objects with DEBUG level by root logger.
+func Debug(a ...any) {
+	rootLogger.Debug(a...)
 }
 
-// Debug calls Log of root logger with DEBUG level.
-func Debug(msg string, a ...any) {
-	rootLogger.Debug(msg, a...)
+// Debugf logs a formatting message with DEBUG level by root logger.
+func Debugf(msg string, a ...any) {
+	rootLogger.Debugf(msg, a...)
 }
 
-// Info calls Log of root logger with INFO level.
-func Info(msg string, a ...any) {
-	rootLogger.Info(msg, a...)
+// Info logs default formatting objects with INFO level by root logger.
+func Info(a ...any) {
+	rootLogger.Info(a...)
 }
 
-// Warn calls Log of root logger with WARN level.
-func Warn(msg string, a ...any) {
-	rootLogger.Warn(msg, a...)
+// Infof logs a formatting message with INFO level by root logger.
+func Infof(msg string, a ...any) {
+	rootLogger.Infof(msg, a...)
 }
 
-// Warning calls Log of root logger with WARNING level.
-func Warning(msg string, a ...any) {
-	rootLogger.Warning(msg, a...)
+// Warn logs default formatting objects with WARN level by root logger.
+func Warn(a ...any) {
+	rootLogger.Warn(a...)
 }
 
-// Error calls Log of root logger with ERROR level.
-func Error(msg string, a ...any) {
-	rootLogger.Error(msg, a...)
+// Warnf logs a formatting message with WARN level by root logger.
+func Warnf(msg string, a ...any) {
+	rootLogger.Warnf(msg, a...)
 }
 
-// Fatal calls Log of root logger with FATAL level.
-func Fatal(msg string, a ...any) {
-	rootLogger.Fatal(msg, a...)
+// Warning logs default formatting objects with WARNING level by root logger.
+func Warning(a ...any) {
+	rootLogger.Warning(a...)
 }
 
-// Critical calls Log of root logger with CRITICAL level.
-func Critical(msg string, a ...any) {
-	rootLogger.Critical(msg, a...)
+// Warningf logs a formatting message with WARNING level by root logger.
+func Warningf(msg string, a ...any) {
+	rootLogger.Warningf(msg, a...)
+}
+
+// Error logs default formatting objects with ERROR level by root logger.
+func Error(a ...any) {
+	rootLogger.Error(a...)
+}
+
+// Errorf logs a formatting message with ERROR level by root logger.
+func Errorf(msg string, a ...any) {
+	rootLogger.Errorf(msg, a...)
+}
+
+// Fatal logs default formatting objects with FATAL level by root logger.
+func Fatal(a ...any) {
+	rootLogger.Fatal(a...)
+}
+
+// Fatalf logs a formatting message with FATAL level by root logger.
+func Fatalf(msg string, a ...any) {
+	rootLogger.Fatalf(msg, a...)
+}
+
+// Critical logs default formatting objects with CRITICAL level by root logger.
+func Critical(a ...any) {
+	rootLogger.Critical(a...)
+}
+
+// Criticalf logs a formatting message with DEBUG level by root logger.
+func Criticalf(msg string, a ...any) {
+	rootLogger.Criticalf(msg, a...)
+}
+
+// Log logs default formatting objects with a custom level by root logger.
+func Log(level int, a ...any) {
+	rootLogger.Log(level, a...)
+}
+
+// Logf logs a formatting message with a custom level by root logger.
+func Logf(level int, msg string, a ...any) {
+	rootLogger.Logf(level, msg, a...)
 }

--- a/xylog/root_test.go
+++ b/xylog/root_test.go
@@ -69,14 +69,32 @@ func TestRootLog(t *testing.T) {
 
 	testRootLogger(t, func(loggerLevel int) {
 		for i := range levels {
+			checkLogOutput(t, func() { xylog.Logf(levels[i], "foo") }, "foo",
+				levels[i], loggerLevel)
 			checkLogOutput(t, func() { xylog.Log(levels[i], "foo") }, "foo",
 				levels[i], loggerLevel)
 		}
 	})
 }
 
-func TestRootLogMethods(t *testing.T) {
+func TestRootLogfMethods(t *testing.T) {
 	var methods = map[int]func(string, ...any){
+		xylog.DEBUG:    xylog.Debugf,
+		xylog.INFO:     xylog.Infof,
+		xylog.WARN:     xylog.Warnf,
+		xylog.ERROR:    xylog.Errorf,
+		xylog.CRITICAL: xylog.Criticalf,
+	}
+
+	testRootLogger(t, func(loggerLevel int) {
+		for level, method := range methods {
+			checkLogOutput(t, func() { method("foo") }, "foo", level, loggerLevel)
+		}
+	})
+}
+
+func TestRootLogMethods(t *testing.T) {
+	var methods = map[int]func(...any){
 		xylog.DEBUG:    xylog.Debug,
 		xylog.INFO:     xylog.Info,
 		xylog.WARN:     xylog.Warn,

--- a/xysched/task.go
+++ b/xysched/task.go
@@ -150,7 +150,7 @@ func (t *Task) run() {
 			if r := recover(); r != nil {
 				var e, ok = r.(error)
 				if !ok {
-					e = CallError.New("%s", r)
+					e = CallError.New(r)
 				}
 				t.lock.LockFunc(func() { t.recover = e })
 				if len(t.onfailure) == 0 {


### PR DESCRIPTION
#### Issue

-   https://xybor.atlassian.net/browse/PLF-76

#### Description

-   All methods with formatting string should have two forms:
    ```
    Log(a ...any)
    Logf(s msg, a ...any)
    ````

#### Changes

-   [ ] Fix bug
-   [x] New feature
-   [x] Documentation
-   [x] Backward incompatible change

#### Testing

-   Unittest.

#### Checklist

-   [x] Check README.md.
-   [x] Check CHANGELOG.md
-   [x] Check comments.
